### PR TITLE
Adding Topological Map field to recorded statistics

### DIFF
--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -37,6 +37,7 @@ class TopologicalNavServer(object):
         self._action_name = name
         rospy.loginfo("Loading file from map %s", filename)
         self.lnodes = self.loadMap(filename)
+        self.topol_map = filename
         rospy.loginfo(" ...done")
 
         if mode == "Node_by_Node" :
@@ -163,7 +164,7 @@ class TopologicalNavServer(object):
         nnodes=len(route)
         Orig = route[0].name
         Targ = route[nnodes-1].name
-        self.stat=nav_stats(Orig, Targ)
+        self.stat=nav_stats(Orig, Targ, self.topol_map)
         dt_text=self.stat.get_start_time_str()
         rospy.loginfo("%d Nodes on route" %nnodes)
         rospy.loginfo("navigation started on %s" %dt_text)

--- a/topological_navigation/src/topological_navigation/navigation_stats.py
+++ b/topological_navigation/src/topological_navigation/navigation_stats.py
@@ -4,10 +4,11 @@ from datetime import datetime
 
 class nav_stats(object):
     
-    def __init__(self, origin, target):
+    def __init__(self, origin, target, topol_map):
         self.status= "active"
         self.origin=origin
         self.target=target
+        self.topological_map = topol_map
         self.set_start()
     
     def set_start(self):


### PR DESCRIPTION
Including this field is important since there may be several nodes named equally on different topological maps and when running different simulations on the same machine if there is no indication of which map the measurement gathered corresponds to, it becomes useless.
