### PR TITLE
MongoDB-backed map switching node

### DIFF
--- a/message_store_map_switcher/CMakeLists.txt
+++ b/message_store_map_switcher/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   map_server  
   nav_msgs
   ros_datacentre_cpp_client
+  message_generation
 )
 
 ## System dependencies are found with CMake's conventions
@@ -17,7 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
 ## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
+catkin_python_setup()
 
 ################################################
 ## Declare ROS messages, services and actions ##
@@ -51,11 +52,10 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
+add_service_files (
+  FILES
+  PublishMap.srv
+)
 
 ## Generate actions in the 'action' folder
 # add_action_files(
@@ -65,7 +65,7 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
+generate_messages()
 #   DEPENDENCIES
 #   nav_msgs
 # )
@@ -126,10 +126,10 @@ target_link_libraries(message_store_map_saver
 
 ## Mark executable scripts (Python etc.) for installation
 ## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
+install(PROGRAMS
+  scripts/message_store_map_server.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 ## Mark executables and/or libraries for installation
 install(TARGETS message_store_map_saver

--- a/message_store_map_switcher/CMakeLists.txt
+++ b/message_store_map_switcher/CMakeLists.txt
@@ -54,7 +54,7 @@ catkin_python_setup()
 ## Generate services in the 'srv' folder
 add_service_files (
   FILES
-  PublishMap.srv
+  SwitchMap.srv
 )
 
 ## Generate actions in the 'action' folder

--- a/message_store_map_switcher/CMakeLists.txt
+++ b/message_store_map_switcher/CMakeLists.txt
@@ -1,0 +1,166 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(message_store_map_switcher)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  map_server  
+  nav_msgs
+  ros_datacentre_cpp_client
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependencies might have been
+##     pulled in transitively but can be declared for certainty nonetheless:
+##     * add a build_depend tag for "message_generation"
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   nav_msgs
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES message_store_map_switcher
+#  CATKIN_DEPENDS map_server nav_msgs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include)
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a cpp library
+# add_library(message_store_map_switcher
+#   src/${PROJECT_NAME}/message_store_map_switcher.cpp
+# )
+
+# Declare a cpp executable
+add_executable(message_store_map_saver src/message_store_map_saver.cpp)
+
+## Add cmake target dependencies of the executable/library
+## as an example, message headers may need to be generated before nodes
+add_dependencies(message_store_map_saver ros_datacentre_msgs_generate_messages_cpp ros_datacentre_cpp_client)
+
+# Specify libraries to link a library or executable target against
+target_link_libraries(message_store_map_saver	
+    SDL
+    SDL_image
+    yaml-cpp
+  ${catkin_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+install(TARGETS message_store_map_saver
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_message_store_map_switcher.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/message_store_map_switcher/README.md
+++ b/message_store_map_switcher/README.md
@@ -1,0 +1,26 @@
+# Message Store Map Server
+
+This package provides tools for serving OccupancyGrid maps from the ros_datacentre. 
+
+## Running the datacentre
+
+All of the below assumes you have the `ros_datacentre` nodes running. Do this with:
+
+```bash
+roslaunch ros_datacentre datacentre.launch 
+```
+
+## Adding maps to the datacentre
+
+At the moment maps must be added using the `message_store_map_saver` executable. This loads a map described by a yaml file (using code from the main `map_server`) and then inserts the map into the message store with the name up to the last "." in the yaml file name. Usage is:
+
+```bash
+rosrun message_store_map_switcher message_store_map_saver <map.yaml>
+```
+
+E.g. 
+```
+rosrun message_store_map_switcher message_store_map_saver cs_lg.yaml
+```
+
+Results in a map named `cs_lg` being added to the message store. This currently uses the default database and collection (both named `message_store`).

--- a/message_store_map_switcher/README.md
+++ b/message_store_map_switcher/README.md
@@ -24,3 +24,39 @@ rosrun message_store_map_switcher message_store_map_saver cs_lg.yaml
 ```
 
 Results in a map named `cs_lg` being added to the message store. This currently uses the default database and collection (both named `message_store`).
+
+## Running the map server
+
+The `message_store_map_server` can be started as follows:
+
+```bash
+rosrun message_store_map_switcher message_store_map_server.py
+```
+
+This will start it without any map being published. If you want to start with a default map you can use the `-d` command line parameter:
+
+```bash
+rosrun message_store_map_switcher message_store_map_server.py -d cs_lg
+```
+
+This can be overridden with the ROS parameter "default_map". 
+
+## Switching maps
+
+To switch to another map from the message store, you must use the `message_store_map_switcher/SwitchMap` service at `/switch_map`. This accepts a string for the map name and returns a boolean if the map was switched. For example,
+
+```bash
+rosservice call /switch_map "cs_lg"
+result: True
+```
+
+```bash
+rosservice call /switch_map "not_cs_lg"
+result: False
+```
+
+
+
+
+
+

--- a/message_store_map_switcher/package.xml
+++ b/message_store_map_switcher/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package>
+  <name>message_store_map_switcher</name>
+  <version>0.0.0</version>
+  <description>A package for manipulating and serving maps from the ros_datacentre.</description>
+
+  <maintainer email="n.a.hawes@cs.bham.ac.uk">Nick Hawes</maintainer>
+
+  <license>MIT</license>
+
+  <author email="n.a.hawes@cs.bham.ac.uk">Nick Hawes</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>map_server</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>ros_datacentre_cpp_client</build_depend>
+
+  <run_depend>map_server</run_depend>
+  <run_depend>nav_msgs</run_depend>
+  <run_depend>ros_datacentre</run_depend>
+  <run_depend>ros_datacentre_cpp_client</run_depend>
+
+</package>

--- a/message_store_map_switcher/package.xml
+++ b/message_store_map_switcher/package.xml
@@ -14,6 +14,7 @@
   <build_depend>map_server</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>ros_datacentre_cpp_client</build_depend>
+  <build_depend>message_generation</build_depend>
 
   <run_depend>map_server</run_depend>
   <run_depend>nav_msgs</run_depend>

--- a/message_store_map_switcher/scripts/message_store_map_server.py
+++ b/message_store_map_switcher/scripts/message_store_map_server.py
@@ -14,7 +14,7 @@ class MessageStoreMapServer:
     def __init__(self):
         self.msg_store = MessageStoreProxy()
         self.map_publisher = rospy.Publisher('/map', OccupancyGrid, latch=True)
-        self.publish_map_serv = rospy.Service('/publish_map', SwitchMap, self.serve_map_srv)
+        self.publish_map_serv = rospy.Service('/switch_map', SwitchMap, self.serve_map_srv)
 
     def serve_map_srv(self, req):
         return self.serve_map(req.map_name)         

--- a/message_store_map_switcher/scripts/message_store_map_server.py
+++ b/message_store_map_switcher/scripts/message_store_map_server.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import rospy
+import ros_datacentre_msgs.srv as dc_srv
+import ros_datacentre.util as dc_util
+from ros_datacentre.message_store import MessageStoreProxy
+import StringIO
+from optparse import OptionParser
+from nav_msgs.msg import OccupancyGrid
+
+class MessageStoreMapServer:
+    def __init__(self):
+        self.msg_store = MessageStoreProxy()
+        self.map_publisher = rospy.Publisher('/map', OccupancyGrid, latch=True)
+
+    def serve_map(self, name):
+        try:
+            map = self.msg_store.query_named(name, OccupancyGrid._type)
+            self.map_publisher.publish(map)
+        except rospy.ServiceException, e:
+            print "Service call failed: %s"%e
+
+
+if __name__ == '__main__':
+    rospy.init_node("message_store_map_server")
+
+    parser = OptionParser()
+    parser.add_option("-d", "--default", dest="map_name", help="name of default map to publish")
+    (options, args) = parser.parse_args()
+    map_name = rospy.get_param("default_map", options.map_name)
+
+    if map_name is None :
+        parser.error("Default map name must be set by either -d/--default or via the default_map ros param")
+
+
+    map_server = MessageStoreMapServer()
+    map_server.serve_map(map_name)
+    rospy.spin()

--- a/message_store_map_switcher/scripts/message_store_map_server.py
+++ b/message_store_map_switcher/scripts/message_store_map_server.py
@@ -8,19 +8,29 @@ from ros_datacentre.message_store import MessageStoreProxy
 import StringIO
 from optparse import OptionParser
 from nav_msgs.msg import OccupancyGrid
+from message_store_map_switcher.srv import SwitchMap
 
 class MessageStoreMapServer:
     def __init__(self):
         self.msg_store = MessageStoreProxy()
         self.map_publisher = rospy.Publisher('/map', OccupancyGrid, latch=True)
+        self.publish_map_serv = rospy.Service('/publish_map', SwitchMap, self.serve_map_srv)
+
+    def serve_map_srv(self, req):
+        return self.serve_map(req.map_name)         
 
     def serve_map(self, name):
         try:
             map = self.msg_store.query_named(name, OccupancyGrid._type)
-            self.map_publisher.publish(map)
+            if map is None:
+                rospy.logwarn("No map found with name \"%s\"", name)
+                return False
+            else:
+                self.map_publisher.publish(map)
+                return True
         except rospy.ServiceException, e:
             print "Service call failed: %s"%e
-
+            return False
 
 if __name__ == '__main__':
     rospy.init_node("message_store_map_server")
@@ -30,10 +40,13 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
     map_name = rospy.get_param("default_map", options.map_name)
 
-    if map_name is None :
-        parser.error("Default map name must be set by either -d/--default or via the default_map ros param")
-
 
     map_server = MessageStoreMapServer()
-    map_server.serve_map(map_name)
+
+    if map_name is None :
+        rospy.logwarn("No default map set via -d/--default command line, or ros param \"default_map\", so no map being published")
+    else:
+        # serve the default map
+        map_server.serve_map(map_name)
+    
     rospy.spin()

--- a/message_store_map_switcher/setup.py
+++ b/message_store_map_switcher/setup.py
@@ -1,0 +1,11 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['message_store_map_switcher'],
+    package_dir={'': 'src'})
+
+setup(**setup_args)

--- a/message_store_map_switcher/src/message_store_map_saver.cpp
+++ b/message_store_map_switcher/src/message_store_map_saver.cpp
@@ -1,0 +1,139 @@
+#include "ros_datacentre/message_store.h"
+#include "map_server/image_loader.h"
+
+#include "ros/ros.h"
+
+#include "yaml-cpp/yaml.h"
+#include <libgen.h>
+#include <fstream>
+
+
+
+
+using namespace ros_datacentre;
+
+
+
+#define USAGE "\nUSAGE: message_store_map_saver <map.yaml>\n" \
+              "  map.yaml: map description file\n"
+
+void loadMapFromFile(ros::NodeHandle & private_nh, 
+						const std::string & fname, 
+						nav_msgs::GetMap::Response & mapResponse) {
+
+	std::string mapfname;   
+	double origin[3];
+	int negate;
+	double occ_th, free_th;
+	std::string frame_id;	
+	private_nh.param("frame_id", frame_id, std::string("map"));
+	double res;
+
+	//mapfname = fname + ".pgm";
+	//std::ifstream fin((fname + ".yaml").c_str());
+	std::ifstream fin(fname.c_str());
+	if (fin.fail()) {
+	  ROS_ERROR("message_store_map_saver could not open %s.", fname.c_str());
+	  exit(-1);
+	}
+
+	YAML::Parser parser(fin);   
+	YAML::Node doc;
+	parser.GetNextDocument(doc);
+	
+	try { 
+	  doc["resolution"] >> res; 
+	} catch (YAML::InvalidScalar) { 
+	  ROS_ERROR("The map does not contain a resolution tag or it is invalid.");
+	  exit(-1);
+	}
+
+	try { 
+	  doc["negate"] >> negate; 
+	} catch (YAML::InvalidScalar) { 
+	  ROS_ERROR("The map does not contain a negate tag or it is invalid.");
+	  exit(-1);
+	}
+	
+	try { 
+	  doc["occupied_thresh"] >> occ_th; 
+	} catch (YAML::InvalidScalar) { 
+	  ROS_ERROR("The map does not contain an occupied_thresh tag or it is invalid.");
+	  exit(-1);
+	}
+	
+	try { 
+	  doc["free_thresh"] >> free_th; 
+	} catch (YAML::InvalidScalar) { 
+	  ROS_ERROR("The map does not contain a free_thresh tag or it is invalid.");
+	  exit(-1);
+	}
+	
+	try { 
+	  doc["origin"][0] >> origin[0]; 
+	  doc["origin"][1] >> origin[1]; 
+	  doc["origin"][2] >> origin[2]; 
+	} catch (YAML::InvalidScalar) { 
+	  ROS_ERROR("The map does not contain an origin tag or it is invalid.");
+	  exit(-1);
+	}
+	
+	try { 
+
+	  doc["image"] >> mapfname; 
+
+	  // TODO: make this path-handling more robust
+	  if(mapfname.size() == 0)
+	  {
+	    ROS_ERROR("The image tag cannot be an empty string.");
+	    exit(-1);
+	  }
+	  if(mapfname[0] != '/')
+	  {
+	    // dirname can modify what you pass it
+	    char* fname_copy = strdup(fname.c_str());
+	    mapfname = std::string(dirname(fname_copy)) + '/' + mapfname;
+	    free(fname_copy);
+	  }
+	} catch (YAML::InvalidScalar) { 
+	  ROS_ERROR("The map does not contain an image tag or it is invalid.");
+	  exit(-1);
+	}
+
+	ROS_INFO("Loading map from image \"%s\"", mapfname.c_str());
+	map_server::loadMapFromFile(&mapResponse,mapfname.c_str(),res,negate,occ_th,free_th, origin);
+	mapResponse.map.info.map_load_time = ros::Time::now();
+	mapResponse.map.header.frame_id = frame_id;
+	mapResponse.map.header.stamp = ros::Time::now();
+	ROS_INFO("Read a %d X %d map @ %.3lf m/cell",
+	       mapResponse.map.info.width,
+	       mapResponse.map.info.height,
+	       mapResponse.map.info.resolution);
+
+}
+
+
+int main(int argc, char **argv)
+{
+	if(argc != 2) {
+    	ROS_ERROR("%s", USAGE);
+    	exit(-1);
+  	}
+
+	ros::init(argc, argv, "message_store_map_saver");
+	ros::NodeHandle private_nh("~");
+
+	//structure to store map contents in
+    nav_msgs::GetMap::Response mapResponse;
+ 	
+    // Code copied from main.cc in map_server -- it loads a map from a yaml file
+
+	std::string fname(argv[1]);   
+	
+	loadMapFromFile(private_nh, fname, mapResponse);
+
+
+	return 0;
+}
+
+

--- a/message_store_map_switcher/src/message_store_map_saver.cpp
+++ b/message_store_map_switcher/src/message_store_map_saver.cpp
@@ -17,6 +17,9 @@ using namespace ros_datacentre;
 #define USAGE "\nUSAGE: message_store_map_saver <map.yaml>\n" \
               "  map.yaml: map description file\n"
 
+/**
+ 	Load a map from a yaml description. Code copied from main.cc in map_server.
+*/
 void loadMapFromFile(ros::NodeHandle & private_nh, 
 						const std::string & fname, 
 						nav_msgs::GetMap::Response & mapResponse) {
@@ -123,15 +126,23 @@ int main(int argc, char **argv)
 	ros::init(argc, argv, "message_store_map_saver");
 	ros::NodeHandle private_nh("~");
 
-	//structure to store map contents in
+	//structure to store map contents in, as required by map_server::loadMapFromFile
     nav_msgs::GetMap::Response mapResponse;
  	
-    // Code copied from main.cc in map_server -- it loads a map from a yaml file
-
+ 	//file name of the yaml file
 	std::string fname(argv[1]);   
 	
+	//load map into mapResponse
 	loadMapFromFile(private_nh, fname, mapResponse);
 
+	//object to store the map in the db	
+	MessageStoreProxy messageStore(private_nh);
+
+	unsigned pos = fname.find(".");
+	std::string mapName = fname.substr(0,pos);
+	ROS_INFO("Saving to message store as \"%s\"", mapName.c_str());
+
+	messageStore.insertNamed(mapName, mapResponse.map);
 
 	return 0;
 }

--- a/message_store_map_switcher/srv/PublishMap.srv
+++ b/message_store_map_switcher/srv/PublishMap.srv
@@ -1,0 +1,4 @@
+# Service used to publish a given map from the database to the /map topic. Definition copied from map_store for potential compatibility
+
+string map_id
+---

--- a/message_store_map_switcher/srv/PublishMap.srv
+++ b/message_store_map_switcher/srv/PublishMap.srv
@@ -1,4 +1,0 @@
-# Service used to publish a given map from the database to the /map topic. Definition copied from map_store for potential compatibility
-
-string map_id
----

--- a/message_store_map_switcher/srv/SwitchMap.srv
+++ b/message_store_map_switcher/srv/SwitchMap.srv
@@ -1,0 +1,5 @@
+# Service used to switch the map server to a new map
+
+string map_name
+---
+bool result


### PR DESCRIPTION
This PR adds the ability to serve maps via the ros_datacentre message store API, as described at https://github.com/strands-project/ros_datacentre/issues/7
