### PR TITLE
monitored navigation now does not cancel move_base when new goal arrives

### DIFF
--- a/monitored_navigation/src/monitored_navigation/navigation.py
+++ b/monitored_navigation/src/monitored_navigation/navigation.py
@@ -66,9 +66,9 @@ class NavActionState(smach.State):
             return 'succeeded'
         elif status==GoalStatus.PREEMPTED:
             return 'preempted'
-        else:
-            
+        else:            
             if (rospy.get_rostime()-self.last_global_plan_time < rospy.Duration.from_sec(1)) and (self.global_plan.poses == []):
+                userdata.n_nav_fails = 0
                 return 'global_plan_failure'
             else:
                 userdata.n_nav_fails = userdata.n_nav_fails + 1
@@ -257,6 +257,8 @@ class HighLevelNav(smach.StateMachine):
         userdata.result=MonitoredNavigationResult()
         if outcome=='succeeded':
             userdata.result.sm_outcome=MonitoredNavigationResult().SUCCEEDED
+        if outcome=='bumper_failure':
+            userdata.result.sm_outcome=MonitoredNavigationResult().BUMPER_FAILURE
         if outcome=='nav_local_plan_failure':
             userdata.result.sm_outcome=MonitoredNavigationResult().LOCAL_PLANNER_FAILURE
         if outcome=='nav_global_plan_failure':

--- a/monitored_navigation/src/monitored_navigation/navigation.py
+++ b/monitored_navigation/src/monitored_navigation/navigation.py
@@ -4,7 +4,7 @@ import smach
 import smach_ros
 
 import actionlib
-from actionlib_msgs.msg import GoalStatus
+from actionlib_msgs.msg import GoalStatus, GoalID
 from move_base_msgs.msg import MoveBaseAction
 
 from strands_navigation_msgs.msg import MonitoredNavigationResult
@@ -35,9 +35,12 @@ class NavActionState(smach.State):
                              )
         
         self.global_plan=None
-        self.last_global_plan_time=None
+        self.last_global_plan_time=rospy.Duration.from_sec(0)
+        self.last_action_cancel_time=rospy.Duration.from_sec(0)
         
         rospy.Subscriber("/move_base/NavfnROS/plan" , Path, self.global_planner_checker_cb)
+        rospy.Subscriber("/monitored_navigation/cancel" , GoalID, self.cancel_checker_cb)
+        
         
         
     def global_planner_checker_cb(self,msg):
@@ -45,7 +48,8 @@ class NavActionState(smach.State):
         self.last_global_plan_time=rospy.get_rostime()
         
         
-        
+    def cancel_checker_cb(self,msg):
+        self.last_action_cancel_time=rospy.get_rostime()    
         
                                                   
     def execute(self, userdata):
@@ -57,8 +61,10 @@ class NavActionState(smach.State):
         while status==GoalStatus.PENDING or status==GoalStatus.ACTIVE:   
             status= action_client.get_state()
             if self.preempt_requested():
-                action_client.cancel_goal()
+                if rospy.get_rostime()-self.last_action_cancel_time< rospy.Duration.from_sec(1):
+                    action_client.cancel_goal()
                 self.service_preempt()
+                return 'preempted'
             action_client.wait_for_result(rospy.Duration(0.2))
         
         if status == GoalStatus.SUCCEEDED:


### PR DESCRIPTION
avoids abrupt stops in intermediary waypoints during mdp policy execution
