### PR TITLE
[RecoverNavBacktrack] Full pre-emption and getting the current planner velocities from move_base instead

### DIFF
--- a/monitored_navigation/launch/monitored_nav.launch
+++ b/monitored_navigation/launch/monitored_nav.launch
@@ -11,6 +11,9 @@
         <include file="$(find nav_help_screen)/launch/help_screen.launch"/>
     </group>
     
+    <node name="previous_positions" pkg="previous_positions_service" type="previous_positions" output="screen"/>
+    <node name="republish_pointcloud" pkg="republish_pointcloud_service" type="republish_pointcloud" output="screen"/>
+    
     <node name="nav_monitor" pkg="monitored_navigation" type="nav_monitor.py" output="screen"/>
 
     <node name="monitored_nav" pkg="monitored_navigation" type="monitored_nav.py" output="screen">

--- a/monitored_navigation/src/monitored_navigation/navigation.py
+++ b/monitored_navigation/src/monitored_navigation/navigation.py
@@ -105,7 +105,7 @@ class RecoverableNav(smach.StateMachine):
         self.userdata.n_nav_fails = 0
         self._nav_action = NavActionState()
         self._recover_nav_backtrack =  RecoverNavBacktrack()
-        self._recover_nav_help = RecoverNavHelp()     
+        self._recover_nav_help = RecoverNavHelp()
         with self:
             smach.StateMachine.add('NAVIGATION',
                                    self._nav_action, 
@@ -123,7 +123,7 @@ class RecoverableNav(smach.StateMachine):
                                    self._recover_nav_help,  
                                    transitions={'succeeded': 'NAVIGATION',
                                                 'failure': 'local_plan_failure',
-                                                'preempted':'preempted'} )                                         
+                                                'preempted':'preempted'} )
             
     def execute(self, userdata=smach.UserData()):
         outcome = smach.StateMachine.execute(self, userdata)   

--- a/monitored_navigation/src/monitored_navigation/navigation.py
+++ b/monitored_navigation/src/monitored_navigation/navigation.py
@@ -105,8 +105,7 @@ class RecoverableNav(smach.StateMachine):
         self.userdata.n_nav_fails = 0
         self._nav_action = NavActionState()
         self._recover_nav_backtrack =  RecoverNavBacktrack()
-        self._recover_nav_help = RecoverNavHelp()
-        
+        self._recover_nav_help = RecoverNavHelp()     
         with self:
             smach.StateMachine.add('NAVIGATION',
                                    self._nav_action, 
@@ -124,8 +123,7 @@ class RecoverableNav(smach.StateMachine):
                                    self._recover_nav_help,  
                                    transitions={'succeeded': 'NAVIGATION',
                                                 'failure': 'local_plan_failure',
-                                                'preempted':'preempted'} )
-                                                
+                                                'preempted':'preempted'} )                                         
             
     def execute(self, userdata=smach.UserData()):
         outcome = smach.StateMachine.execute(self, userdata)   

--- a/monitored_navigation/src/monitored_navigation/navigation.py
+++ b/monitored_navigation/src/monitored_navigation/navigation.py
@@ -106,13 +106,12 @@ class RecoverableNav(smach.StateMachine):
         self._nav_action = NavActionState()
         self._recover_nav_backtrack =  RecoverNavBacktrack()
         self._recover_nav_help = RecoverNavHelp()
-        self._recover_look_around = RecoverLookAround()
         
         with self:
             smach.StateMachine.add('NAVIGATION',
                                    self._nav_action, 
                                    transitions={'succeeded': 'succeeded',
-                                                'local_plan_failure':  'RECOVER_NAVIGATION_BACKTRACK', #RECOVER_LOOK_AROUND
+                                                'local_plan_failure':  'RECOVER_NAVIGATION_BACKTRACK',
                                                 'global_plan_failure':'global_plan_failure',
                                                 'preempted': 'preempted'}
                                    )
@@ -127,11 +126,6 @@ class RecoverableNav(smach.StateMachine):
                                                 'failure': 'local_plan_failure',
                                                 'preempted':'preempted'} )
                                                 
-            smach.StateMachine.add('RECOVER_LOOK_AROUND',
-                                   self._recover_look_around,  
-                                   transitions={'succeeded': 'NAVIGATION',
-                                                'failure': 'RECOVER_NAVIGATION_HELP',
-                                                'preempted':'preempted'})
             
     def execute(self, userdata=smach.UserData()):
         outcome = smach.StateMachine.execute(self, userdata)   

--- a/monitored_navigation/src/monitored_navigation/recover_states.py
+++ b/monitored_navigation/src/monitored_navigation/recover_states.py
@@ -212,8 +212,8 @@ class RecoverNavBacktrack(smach.State):
             print "Got the previous position: ", meter_back.previous_pose.pose.position.x, ", ", meter_back.previous_pose.pose.position.y, ", ",  meter_back.previous_pose.pose.position.z
             
             ptu_goal = PtuGotoGoal();
-            ptu_goal.pan = 159
-            ptu_goal.tilt = 29
+            ptu_goal.pan = 179
+            ptu_goal.tilt = 30
             ptu_goal.pan_vel = 20
             ptu_goal.tilt_vel = 20
             self.ptu_action_client.send_goal(ptu_goal)

--- a/monitored_navigation/src/monitored_navigation/recover_states.py
+++ b/monitored_navigation/src/monitored_navigation/recover_states.py
@@ -116,7 +116,6 @@ class RecoverNavBacktrack(smach.State):
             while status == GoalStatus.PENDING or status == GoalStatus.ACTIVE:   
                 status = self.move_base_action_client.get_state()
                 if self.preempt_requested():
-                    self.move_base_action_client.cancel_goal()
                     self.service_preempt()
                     self.stop_republish()
                     return 'preempted'
@@ -164,6 +163,7 @@ class RecoverNavBacktrack(smach.State):
 
     def service_preempt(self):
         #check if preemption is working
+        self.move_base_action_client.cancel_all_goals()
         smach.State.service_preempt(self)
 
 

--- a/monitored_navigation/src/monitored_navigation/recover_states.py
+++ b/monitored_navigation/src/monitored_navigation/recover_states.py
@@ -49,7 +49,7 @@ class RecoverNavBacktrack(smach.State):
             
             try:
                 previous_position = rospy.ServiceProxy('previous_position', PreviousPosition)
-                meter_back = previous_position(1.5)
+                meter_back = previous_position(1.0)
             except rospy.ServiceException, e:
                 rospy.logwarn("Couldn't get previous position service, returning failure.")
                 return 'failure'
@@ -65,7 +65,7 @@ class RecoverNavBacktrack(smach.State):
                 
             print "Managed to republish pointcloud."
                       
-            params = { 'max_vel_x' : -0.1, 'min_vel_x' : -0.4 }
+            params = { 'max_vel_x' : -0.1, 'min_vel_x' : -0.2 }
             config = self.move_base_reconfig_client.update_configuration(params)
             
             ptu_goal = PtuGotoGoal();

--- a/monitored_navigation/src/monitored_navigation/recover_states.py
+++ b/monitored_navigation/src/monitored_navigation/recover_states.py
@@ -65,6 +65,8 @@ class RecoverNavBacktrack(smach.State):
                 
             print "Managed to republish pointcloud."
                       
+            max_vel_x = rospy.get_param("/move_base/DWAPlannerROS/max_vel_x")
+            min_vel_x = rospy.get_param("/move_base/DWAPlannerROS/min_vel_x")
             params = { 'max_vel_x' : -0.1, 'min_vel_x' : -0.2 }
             config = self.move_base_reconfig_client.update_configuration(params)
             
@@ -93,7 +95,7 @@ class RecoverNavBacktrack(smach.State):
                 self.service_preempt()
                 return 'preempted'
             
-            params = { 'max_vel_x' : 0.95, 'min_vel_x' : 0.1 }
+            params = { 'max_vel_x' : max_vel_x, 'min_vel_x' : min_vel_x }
             config = self.move_base_reconfig_client.update_configuration(params)
 
             try:

--- a/monitored_navigation/src/monitored_navigation/recover_states.py
+++ b/monitored_navigation/src/monitored_navigation/recover_states.py
@@ -135,7 +135,7 @@ class RecoverLookAround(smach.State):
             self.ptu_action_client.send_goal(ptu_goal)
             #self.ptu_action_client.wait_for_result()
 
-            return 'succeded'
+            return 'succeeded'
         else:
             return 'failure'
         

--- a/monitored_navigation/src/monitored_navigation/recover_states.py
+++ b/monitored_navigation/src/monitored_navigation/recover_states.py
@@ -212,7 +212,7 @@ class RecoverNavBacktrack(smach.State):
             print "Got the previous position: ", meter_back.previous_pose.pose.position.x, ", ", meter_back.previous_pose.pose.position.y, ", ",  meter_back.previous_pose.pose.position.z
             
             ptu_goal = PtuGotoGoal();
-            ptu_goal.pan = 177
+            ptu_goal.pan = 159
             ptu_goal.tilt = 29
             ptu_goal.pan_vel = 20
             ptu_goal.tilt_vel = 20


### PR DESCRIPTION
This pull request does several things:
- Adding pre-emption for move_base and in general
- Resets point cloud publishing etc when pre-empting, resets PTU
- Adding a behaviour that does a sweep, this is not supported in scitos_2d_navigation atm
- Returning 'success' if local planner fails, 'failure' if global planner fails
- Going backwards slower now (0.2)
- Launch the required nodes (`republish_pointcloud_service` and `previous_positions_service`) together with monitored_navigation
