### PR TITLE
[backtrack_behaviour] This implements the backtrack recovery as an action server

### DIFF
--- a/backtrack_behaviour/CMakeLists.txt
+++ b/backtrack_behaviour/CMakeLists.txt
@@ -1,0 +1,180 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(backtrack_behaviour)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  actionlib
+  actionlib_msgs
+  rospy
+  std_msgs
+  std_srvs
+  dynamic_reconfigure 
+  scitos_msgs
+  strands_navigation_msgs
+  previous_positions_service
+  republish_pointcloud_service
+  scitos_ptu
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+#catkin_python_setup()
+
+find_package(catkin REQUIRED dynamic_reconfigure)
+#generate_dynamic_reconfigure_options(
+#  cfg/NavFailTresholds.cfg
+#)
+
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependencies might have been
+##     pulled in transitively but can be declared for certainty nonetheless:
+##     * add a build_depend tag for "message_generation"
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+add_action_files(
+  FILES
+  Backtrack.action
+)
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+  actionlib_msgs
+)
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES monitored_navigation
+#  CATKIN_DEPENDS actionlib actionlib_msgs dynamic_reconfigure rospy smach smach_ros std_msgs std_srvs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include)
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a cpp library
+# add_library(monitored_navigation
+#   src/${PROJECT_NAME}/monitored_navigation.cpp
+# )
+
+## Declare a cpp executable
+# add_executable(monitored_navigation_node src/monitored_navigation_node.cpp)
+
+## Add cmake target dependencies of the executable/library
+## as an example, message headers may need to be generated before nodes
+# add_dependencies(monitored_navigation_node monitored_navigation_generate_messages_cpp)
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(monitored_navigation_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS monitored_navigation monitored_navigation_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#install(PROGRAMS scripts/monitored_nav.py
+#         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+#)
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_monitored_navigation.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/backtrack_behaviour/action/Backtrack.action
+++ b/backtrack_behaviour/action/Backtrack.action
@@ -1,0 +1,8 @@
+# Define the goal
+float32 meters_back  # Specify which dishwasher we want to use
+---
+# Define the result
+string status
+---
+# Define a feedback message
+string status

--- a/backtrack_behaviour/launch/backtrack.launch
+++ b/backtrack_behaviour/launch/backtrack.launch
@@ -1,0 +1,7 @@
+<launch>
+ 
+    <node name="previous_positions" pkg="previous_positions_service" type="previous_positions" output="screen"/>
+    <node name="republish_pointcloud" pkg="republish_pointcloud_service" type="republish_pointcloud" output="screen"/>
+    <node name="backtrack_server" pkg="backtrack_behaviour" type="backtrack_server.py" output="screen"/>
+    
+</launch>

--- a/backtrack_behaviour/package.xml
+++ b/backtrack_behaviour/package.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<package>
+  <name>backtrack_behaviour</name>
+  <version>0.0.0</version>
+  <description>The backtrack_behaviour package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="nilsbore@gmail.com">Nils Bore</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>BSD</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/monitored_navigation</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>actionlib</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
+  <build_depend>scitos_msgs</build_depend>
+  <build_depend>strands_navigation_msgs</build_depend>
+  <build_depend>scitos_ptu</build_depend>
+  <build_depend>move_base_msgs</build_depend>
+  <build_depend>previous_positions_service</build_depend>
+  <build_depend>republish_pointcloud_service</build_depend>
+  
+  <run_depend>actionlib</run_depend>
+  <run_depend>actionlib_msgs</run_depend>
+  <run_depend>dynamic_reconfigure</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
+  <run_depend>scitos_msgs</run_depend>
+  <run_depend>strands_navigation_msgs</run_depend>
+  <run_depend>scitos_ptu</run_depend>
+  <run_depend>move_base_msgs</run_depend>
+  <run_depend>previous_positions_service</run_depend>
+  <run_depend>republish_pointcloud_service</run_depend>
+  
+  
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- You can specify that this package is a metapackage here: -->
+    <!-- <metapackage/> -->
+
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/backtrack_behaviour/scripts/backtrack_server.py
+++ b/backtrack_behaviour/scripts/backtrack_server.py
@@ -127,10 +127,12 @@ class BacktrackServer(object):
         
         if self.server.is_preempt_requested():
             self.reset_ptu()
+            pose_sub.unregister()
             self.service_preempt()
             return
             
         if self.start_republish() == False:
+            pose_sub.unregister()
             self.server.set_aborted()
             return # 'failure'
             
@@ -156,6 +158,7 @@ class BacktrackServer(object):
                 self.stop_republish()
                 self.reset_move_base_pars()
                 self.reset_ptu()
+                pose_sub.unregister()
                 self.service_preempt()
                 return
             if self.gone_too_far(goal.meters_back):
@@ -163,6 +166,7 @@ class BacktrackServer(object):
                 self.reset_move_base_pars()
                 self.reset_ptu()
                 self.move_base_action_client.cancel_all_goals()
+                pose_sub.unregister()
                 self.server.set_aborted()
                 return
             self.move_base_action_client.wait_for_result(rospy.Duration(0.2))

--- a/backtrack_behaviour/scripts/backtrack_server.py
+++ b/backtrack_behaviour/scripts/backtrack_server.py
@@ -1,0 +1,185 @@
+#! /usr/bin/env python
+
+import rospy
+
+#import smach
+#import smach_ros
+
+#from scitos_msgs.srv import ResetMotorStop
+#from scitos_msgs.srv import EnableMotors
+#from std_srvs.srv import Empty
+#from scitos_msgs.msg import MotorStatus
+#from geometry_msgs.msg import Twist
+
+from nav_msgs.msg import Path
+from move_base_msgs.msg import *
+import dynamic_reconfigure.client
+from scitos_ptu.msg import *
+from previous_positions_service.srv import PreviousPosition
+from republish_pointcloud_service.srv import RepublishPointcloud
+from actionlib_msgs.msg import *
+
+import actionlib
+
+from strands_navigation_msgs.srv import AskHelp, AskHelpRequest
+from backtrack_behaviour.msg import BacktrackAction, BacktrackResult, BacktrackFeedback
+
+#from logger import Loggable
+
+# this file has the recovery states that will be used when some failures are
+# detected. There is a recovery behaviour for move_base and another for when the
+# bumper is pressed
+
+class BacktrackServer(object):
+    def __init__(self):
+        rospy.init_node('backtrack_actionserver')
+
+        self.ptu_action_client = actionlib.SimpleActionClient('/SetPTUState', PtuGotoAction)
+        self.move_base_action_client = actionlib.SimpleActionClient('/move_base', MoveBaseAction)
+        self.move_base_reconfig_client = dynamic_reconfigure.client.Client('/move_base/DWAPlannerROS')
+        
+        self.global_plan = None
+        self.last_global_plan_time = None
+        rospy.Subscriber("/move_base/NavfnROS/plan" , Path, self.global_planner_checker_cb)
+        
+        self.feedback = BacktrackFeedback()
+        self.result = BacktrackResult()
+        
+        self.server = actionlib.SimpleActionServer('do_backtrack', BacktrackAction, self.execute, False)
+        self.server.start()
+        
+    def global_planner_checker_cb(self, msg):
+        self.global_plan = msg
+        self.last_global_plan_time = rospy.get_rostime()
+    
+    def stop_republish(self):
+        try:
+            republish_pointcloud = rospy.ServiceProxy('republish_pointcloud', RepublishPointcloud)
+            republish_pointcloud(False, '', '', 0.0)
+        except rospy.ServiceException, e:
+            rospy.logwarn("Couldn't stop republish pointcloud service, returning failure.")
+            return False
+        return True
+    
+    def start_republish(self):
+        try:
+            republish_pointcloud = rospy.ServiceProxy('republish_pointcloud', RepublishPointcloud)
+            republish_pointcloud(True, '/head_xtion/depth/points', '/move_base/head_subsampled', 0.05)
+        except rospy.ServiceException, e:
+            rospy.logwarn("Couldn't get republish pointcloud service, returning failure.")
+            return False
+        return True
+
+    def reset_ptu(self):
+        ptu_goal = PtuGotoGoal();
+        ptu_goal.pan = 0
+        ptu_goal.tilt = 0
+        ptu_goal.pan_vel = 20
+        ptu_goal.tilt_vel = 20
+        self.ptu_action_client.send_goal(ptu_goal)
+        #self.ptu_action_client.wait_for_result()
+
+    def reset_move_base_pars(self):
+        params = { 'max_vel_x' : self.max_vel_x, 'min_vel_x' : self.min_vel_x }
+        config = self.move_base_reconfig_client.update_configuration(params)
+                                                  
+    def execute(self, goal):
+        #back track in elegant fashion     
+        try:
+            previous_position = rospy.ServiceProxy('previous_position', PreviousPosition)
+            meter_back = previous_position(goal.meters_back)
+        except rospy.ServiceException, e:
+            rospy.logwarn("Couldn't get previous position service, returning failure.")
+            self.server.set_aborted()
+            return # 'failure'
+            
+        print "Got the previous position: ", meter_back.previous_pose.pose.position.x, ", ", meter_back.previous_pose.pose.position.y, ", ",  meter_back.previous_pose.pose.position.z
+        
+        self.feedback.status = "Moving the PTU"
+        self.server.publish_feedback(self.feedback)
+        ptu_goal = PtuGotoGoal();
+        ptu_goal.pan = 179
+        ptu_goal.tilt = 30
+        ptu_goal.pan_vel = 20
+        ptu_goal.tilt_vel = 20
+        self.ptu_action_client.send_goal(ptu_goal)
+        self.ptu_action_client.wait_for_result()
+        
+        if self.server.is_preempt_requested():
+            self.service_preempt()
+            return
+            
+        if self.start_republish() == False:
+            self.server.set_aborted()
+            return # 'failure'
+            
+        print "Managed to republish pointcloud."
+        
+        self.max_vel_x = rospy.get_param("/move_base/DWAPlannerROS/max_vel_x")
+        self.min_vel_x = rospy.get_param("/move_base/DWAPlannerROS/min_vel_x")
+        params = { 'max_vel_x' : 0.2, 'min_vel_x' : -0.2 }
+        config = self.move_base_reconfig_client.update_configuration(params)
+        
+        self.feedback.status = "Moving the robot"
+        self.server.publish_feedback(self.feedback)
+        move_goal = MoveBaseGoal()
+        move_goal.target_pose.pose = meter_back.previous_pose.pose
+        move_goal.target_pose.header.frame_id = meter_back.previous_pose.header.frame_id
+        self.move_base_action_client.cancel_all_goals()
+        rospy.sleep(rospy.Duration.from_sec(1))
+        #print movegoal
+        self.move_base_action_client.send_goal(move_goal)
+        status = self.move_base_action_client.get_state()
+        while status == GoalStatus.PENDING or status == GoalStatus.ACTIVE:   
+            status = self.move_base_action_client.get_state()
+            if self.server.is_preempt_requested():
+                self.service_preempt()
+                self.stop_republish()
+                self.reset_move_base_pars()
+                self.reset_ptu()
+                return
+            self.move_base_action_client.wait_for_result(rospy.Duration(0.2))
+        
+        self.reset_move_base_pars()
+        
+        if self.server.is_preempt_requested():
+            self.service_preempt()
+            self.stop_republish()
+            return
+
+        if self.stop_republish() == False:
+            self.server.set_aborted()
+            return # 'failure'
+        
+        self.reset_ptu()
+
+        print "Reset PTU, move_base parameters and stopped republishing pointcloud."
+        
+        if self.server.is_preempt_requested():
+            self.service_preempt()
+            return
+            
+        if self.move_base_action_client.get_state() == GoalStatus.SUCCEEDED: #set the previous goal again
+            self.result.status = 'reached_point'
+            self.server.set_succeeded(self.result)
+            return
+        elif status == GoalStatus.PREEMPTED:
+            self.service_preempt()
+            return
+        else:
+            if (rospy.get_rostime() - self.last_global_plan_time < rospy.Duration.from_sec(1)) and (self.global_plan.poses == []):
+                self.server.set_aborted()
+                return # 'failure' # 'global_plan_failure'
+            else: # 'local_plan_failure'
+                self.result.status = 'local_plan_failure' # 'succeeded'
+                self.server.set_succeeded(self.result)
+                return      
+
+    def service_preempt(self):
+        #check if preemption is working
+        self.move_base_action_client.cancel_all_goals()
+        self.server.set_preempted()
+
+if __name__ == '__main__':
+    server = BacktrackServer()
+    rospy.spin()

--- a/backtrack_behaviour/scripts/backtrack_server.py
+++ b/backtrack_behaviour/scripts/backtrack_server.py
@@ -108,6 +108,7 @@ class BacktrackServer(object):
         self.ptu_action_client.wait_for_result()
         
         if self.server.is_preempt_requested():
+            self.reset_ptu()
             self.service_preempt()
             return
             

--- a/monitored_navigation/src/monitored_navigation/recover_states.py
+++ b/monitored_navigation/src/monitored_navigation/recover_states.py
@@ -14,7 +14,7 @@ from geometry_msgs.msg import Twist
 #from scitos_ptu.msg import *
 #from previous_positions_service.srv import PreviousPosition
 #from republish_pointcloud_service.srv import RepublishPointcloud
-#from actionlib_msgs.msg import *
+from actionlib_msgs.msg import *
 
 from backtrack_behaviour.msg import *
 
@@ -43,7 +43,7 @@ class RecoverNavBacktrack(smach.State):
                                                   
     def execute(self, userdata):
         print "Failures: ", userdata.n_nav_fails
-        if userdata.n_nav_fails >= self.BACKTRACK_TRIES:
+        if userdata.n_nav_fails > self.BACKTRACK_TRIES:
             return 'failure'
         
         backtrack_goal = BacktrackGoal();
@@ -53,8 +53,8 @@ class RecoverNavBacktrack(smach.State):
         status = self.backtrack_client.get_state()
         while status == GoalStatus.PENDING or status == GoalStatus.ACTIVE:
             status = self.backtrack_client.get_state()
-            if self.server.is_preempt_requested():
-                self.backtrack_client.set_preempted()
+            if self.preempt_requested():
+                self.backtrack_client.cancel_goal()
                 self.service_preempt()
                 return 'preempted'
             self.backtrack_client.wait_for_result(rospy.Duration(0.2))

--- a/monitored_navigation/src/monitored_navigation/recover_states.py
+++ b/monitored_navigation/src/monitored_navigation/recover_states.py
@@ -47,7 +47,7 @@ class RecoverNavBacktrack(smach.State):
             return 'failure'
         
         backtrack_goal = BacktrackGoal();
-        backtrack_goal.meters_back = 0.5;
+        backtrack_goal.meters_back = 0.8;
         #self.backtrack_client.cancel_all_goals()
         self.backtrack_client.send_goal(backtrack_goal)
         status = self.backtrack_client.get_state()

--- a/monitored_navigation/src/monitored_navigation/recover_states.py
+++ b/monitored_navigation/src/monitored_navigation/recover_states.py
@@ -39,7 +39,7 @@ class RecoverNavBacktrack(smach.State):
                              )
 
         self.backtrack_client = actionlib.SimpleActionClient('/do_backtrack', BacktrackAction)
-        self.BACKTRACK_TRIES = 0 #will turn into parameter later
+        self.BACKTRACK_TRIES = 1 #will turn into parameter later
                                                   
     def execute(self, userdata):
         print "Failures: ", userdata.n_nav_fails

--- a/monitored_navigation/src/monitored_navigation/recover_states.py
+++ b/monitored_navigation/src/monitored_navigation/recover_states.py
@@ -39,7 +39,7 @@ class RecoverNavBacktrack(smach.State):
                              )
 
         self.backtrack_client = actionlib.SimpleActionClient('/do_backtrack', BacktrackAction)
-        self.BACKTRACK_TRIES = 1 #will turn into parameter later
+        self.BACKTRACK_TRIES = 0 #will turn into parameter later
                                                   
     def execute(self, userdata):
         print "Failures: ", userdata.n_nav_fails


### PR DESCRIPTION
This implements the backtrack recovery as an action server in a separate package. Maybe it should eventually be moved to scitos_2d_navigation but I'm leaving it here for now. One problem is that it is preempted when close to waypoints but this doesn't seem to lead to any other issues than that the recovery is not executed. If it goes further away from the start than the requested meter's back by planning some odd path, the action gets aborted. Tested this on Rosie but it is hard to see any gains in scenarios that are not staged by me.
