### PR TITLE
Renamed ros_datacentre to mongodb_store

### DIFF
--- a/message_store_map_switcher/CMakeLists.txt
+++ b/message_store_map_switcher/CMakeLists.txt
@@ -7,7 +7,7 @@ project(message_store_map_switcher)
 find_package(catkin REQUIRED COMPONENTS
   map_server  
   nav_msgs
-  ros_datacentre_cpp_client
+  mongodb_store_cpp_client
   message_generation
 )
 
@@ -111,7 +111,7 @@ add_executable(message_store_map_saver src/message_store_map_saver.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
-add_dependencies(message_store_map_saver ros_datacentre_msgs_generate_messages_cpp ros_datacentre_cpp_client)
+add_dependencies(message_store_map_saver mongodb_store_msgs_generate_messages_cpp mongodb_store_cpp_client)
 
 # Specify libraries to link a library or executable target against
 target_link_libraries(message_store_map_saver	

--- a/message_store_map_switcher/README.md
+++ b/message_store_map_switcher/README.md
@@ -1,13 +1,13 @@
 # Message Store Map Server
 
-This package provides tools for serving OccupancyGrid maps from the ros_datacentre. 
+This package provides tools for serving OccupancyGrid maps from the mongodb_store. 
 
 ## Running the datacentre
 
-All of the below assumes you have the `ros_datacentre` nodes running. Do this with:
+All of the below assumes you have the `mongodb_store` nodes running. Do this with:
 
 ```bash
-roslaunch ros_datacentre datacentre.launch 
+roslaunch mongodb_store datacentre.launch 
 ```
 
 ## Adding maps to the datacentre

--- a/message_store_map_switcher/package.xml
+++ b/message_store_map_switcher/package.xml
@@ -2,7 +2,7 @@
 <package>
   <name>message_store_map_switcher</name>
   <version>0.0.0</version>
-  <description>A package for manipulating and serving maps from the ros_datacentre.</description>
+  <description>A package for manipulating and serving maps from the mongodb_store.</description>
 
   <maintainer email="n.a.hawes@cs.bham.ac.uk">Nick Hawes</maintainer>
 
@@ -13,12 +13,12 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>map_server</build_depend>
   <build_depend>nav_msgs</build_depend>
-  <build_depend>ros_datacentre_cpp_client</build_depend>
+  <build_depend>mongodb_store_cpp_client</build_depend>
   <build_depend>message_generation</build_depend>
 
   <run_depend>map_server</run_depend>
   <run_depend>nav_msgs</run_depend>
-  <run_depend>ros_datacentre</run_depend>
-  <run_depend>ros_datacentre_cpp_client</run_depend>
+  <run_depend>mongodb_store</run_depend>
+  <run_depend>mongodb_store_cpp_client</run_depend>
 
 </package>

--- a/message_store_map_switcher/scripts/message_store_map_server.py
+++ b/message_store_map_switcher/scripts/message_store_map_server.py
@@ -2,9 +2,9 @@
 # -*- coding: utf-8 -*-
 
 import rospy
-import ros_datacentre_msgs.srv as dc_srv
-import ros_datacentre.util as dc_util
-from ros_datacentre.message_store import MessageStoreProxy
+import mongodb_store_msgs.srv as dc_srv
+import mongodb_store.util as dc_util
+from mongodb_store.message_store import MessageStoreProxy
 import StringIO
 from optparse import OptionParser
 from nav_msgs.msg import OccupancyGrid

--- a/message_store_map_switcher/src/message_store_map_saver.cpp
+++ b/message_store_map_switcher/src/message_store_map_saver.cpp
@@ -1,4 +1,4 @@
-#include "ros_datacentre/message_store.h"
+#include "mongodb_store/message_store.h"
 #include "map_server/image_loader.h"
 
 #include "ros/ros.h"
@@ -10,7 +10,7 @@
 
 
 
-using namespace ros_datacentre;
+using namespace mongodb_store;
 
 
 

--- a/monitored_navigation/src/monitored_navigation/mongo_logger.py
+++ b/monitored_navigation/src/monitored_navigation/mongo_logger.py
@@ -2,7 +2,7 @@ import rospy
 
 
 from strands_navigation_msgs.msg import MonitoredNavEvent
-from ros_datacentre.message_store import MessageStoreProxy
+from mongodb_store.message_store import MessageStoreProxy
 
 
 #string failure #'global_plan_fail, local_plan_fail, bump_fail, stuck_on_carpet

--- a/topological_map_manager/CMakeLists.txt
+++ b/topological_map_manager/CMakeLists.txt
@@ -4,7 +4,7 @@ project(topological_map_manager)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS rospy std_msgs nav_msgs sensor_msgs scitos_msgs actionlib_msgs ros_datacentre strands_navigation_msgs)
+find_package(catkin REQUIRED COMPONENTS rospy std_msgs nav_msgs sensor_msgs scitos_msgs actionlib_msgs mongodb_store strands_navigation_msgs)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/topological_map_manager/package.xml
+++ b/topological_map_manager/package.xml
@@ -40,7 +40,7 @@
   <run_depend>scitos_msgs</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
-  <run_depend>ros_datacentre</run_depend>
+  <run_depend>mongodb_store</run_depend>
   <run_depend>strands_navigation_msgs</run_depend>
   <run_depend>topological_navigation</run_depend>
 

--- a/topological_map_manager/scripts/visualise_map.py
+++ b/topological_map_manager/scripts/visualise_map.py
@@ -14,7 +14,7 @@ from threading import Timer
 from geometry_msgs.msg import Pose
 from geometry_msgs.msg import Point
 
-from ros_datacentre.message_store import MessageStoreProxy
+from mongodb_store.message_store import MessageStoreProxy
 
 from interactive_markers.interactive_marker_server import *
 #from interactive_markers.menu_handler import *

--- a/topological_navigation/CMakeLists.txt
+++ b/topological_navigation/CMakeLists.txt
@@ -4,7 +4,7 @@ project(topological_navigation)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS rospy std_msgs nav_msgs sensor_msgs scitos_msgs actionlib_msgs ros_datacentre strands_navigation_msgs)
+find_package(catkin REQUIRED COMPONENTS rospy std_msgs nav_msgs sensor_msgs scitos_msgs actionlib_msgs mongodb_store strands_navigation_msgs)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/topological_navigation/package.xml
+++ b/topological_navigation/package.xml
@@ -38,7 +38,7 @@
   <run_depend>scitos_msgs</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
-  <run_depend>ros_datacentre</run_depend>
+  <run_depend>mongodb_store</run_depend>
   <run_depend>strands_navigation_msgs</run_depend>
 
 

--- a/topological_navigation/scripts/localisation.py
+++ b/topological_navigation/scripts/localisation.py
@@ -17,7 +17,7 @@ from std_msgs.msg import String
 import scitos_apps_msgs.msg
 
 from strands_navigation_msgs.msg import TopologicalNode
-from ros_datacentre.message_store import MessageStoreProxy
+from mongodb_store.message_store import MessageStoreProxy
 from topological_navigation.topological_node import *
 
 import topological_navigation.msg

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -19,7 +19,7 @@ from move_base_msgs.msg import *
 from std_msgs.msg import String
 import scitos_apps_msgs.msg
 from strands_navigation_msgs.msg import TopologicalNode
-from ros_datacentre.message_store import MessageStoreProxy
+from mongodb_store.message_store import MessageStoreProxy
 from topological_navigation.topological_node import *
 from topological_navigation.navigation_stats import *
 

--- a/topological_navigation/src/topological_navigation/topological_map.py
+++ b/topological_navigation/src/topological_navigation/topological_map.py
@@ -6,7 +6,7 @@ from topological_navigation.topological_node import *
 from strands_navigation_msgs.msg import TopologicalNode
 
 
-from ros_datacentre.message_store import MessageStoreProxy
+from mongodb_store.message_store import MessageStoreProxy
 #import topological_navigation.msg
 
 

--- a/topological_utils/CMakeLists.txt
+++ b/topological_utils/CMakeLists.txt
@@ -4,7 +4,7 @@ project(topological_utils)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED rospy roscpp std_msgs geometry_msgs message_generation ros_datacentre visualization_msgs)
+find_package(catkin REQUIRED rospy roscpp std_msgs geometry_msgs message_generation mongodb_store visualization_msgs)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/topological_utils/package.xml
+++ b/topological_utils/package.xml
@@ -47,7 +47,7 @@
   <run_depend>rospy</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>geometry_msgs</run_depend>
-  <run_depend>ros_datacentre</run_depend>
+  <run_depend>mongodb_store</run_depend>
 
 
 

--- a/topological_utils/scripts/LoadPointSet.py
+++ b/topological_utils/scripts/LoadPointSet.py
@@ -10,7 +10,7 @@ from strands_navigation_msgs.msg import TopologicalNode
 #from topological_utils.msg import vertex
 #from topological_utils.msg import edge
 #from geometry_msgs.msg import Pose
-from ros_datacentre.message_store import MessageStoreProxy
+from mongodb_store.message_store import MessageStoreProxy
 
 
 if __name__ == '__main__':

--- a/topological_utils/scripts/insert_map.py
+++ b/topological_utils/scripts/insert_map.py
@@ -9,8 +9,8 @@ from topological_utils.msg import Vertex
 from topological_utils.msg import Edge
 
 import pymongo
-#import ros_datacentre.util
-from ros_datacentre.message_store import MessageStoreProxy
+#import mongodb_store.util
+from mongodb_store.message_store import MessageStoreProxy
 
 
 class topological_node(object):
@@ -144,4 +144,4 @@ if __name__ == '__main__':
             n.edges.append(e)
         print n
         msg_store.insert(n,meta)
-        #ros_datacentre.util.store_message(points_db,p,val)
+        #mongodb_store.util.store_message(points_db,p,val)

--- a/topological_utils/scripts/map_collection_change.py
+++ b/topological_utils/scripts/map_collection_change.py
@@ -9,8 +9,8 @@ from topological_utils.msg import Vertex
 from topological_utils.msg import Edge
 
 import pymongo
-#import ros_datacentre.util
-from ros_datacentre.message_store import MessageStoreProxy
+#import mongodb_store.util
+from mongodb_store.message_store import MessageStoreProxy
 
 
 

--- a/topological_utils/scripts/map_export.py
+++ b/topological_utils/scripts/map_export.py
@@ -19,7 +19,7 @@ import scitos_apps_msgs.msg
 
 from strands_navigation_msgs.msg import TopologicalNode
 
-from ros_datacentre.message_store import MessageStoreProxy
+from mongodb_store.message_store import MessageStoreProxy
 import topological_navigation.msg
 
 

--- a/topological_utils/scripts/visualise_map.py
+++ b/topological_utils/scripts/visualise_map.py
@@ -14,7 +14,7 @@ from threading import Timer
 from geometry_msgs.msg import Pose
 from geometry_msgs.msg import Point
 
-from ros_datacentre.message_store import MessageStoreProxy
+from mongodb_store.message_store import MessageStoreProxy
 
 from interactive_markers.interactive_marker_server import *
 from interactive_markers.menu_handler import *


### PR DESCRIPTION
This simply bulk replaces all ros_datacentre strings to mongodb_store strings inside files and also in file names.

Needs strands-project/ros_datacentre#76 to be merged first.
