### PR TITLE
adding monitored_nav to topological_navigation.launch. 

### DIFF
--- a/monitored_navigation/scripts/monitored_nav.py
+++ b/monitored_navigation/scripts/monitored_nav.py
@@ -249,7 +249,7 @@ class MonitoredNavigation:
 if __name__ == '__main__':
     rospy.init_node('monitored_navigation')
     
-    if len(sys.argv) < 2:
+    if len(sys.argv) < 2 or "__name:=" in sys.argv[1]:
         rospy.logwarn("No config yaml file provided. MonitoredNavigation state machine will be initialized without recovery behaviours. To provide a config file do 'rosrun monitored_navigation monitored_nav.py path_to_config_file'. The strands config yaml file is located in monitored_navigation/config/strands.yaml")
         file_name=None
     else:

--- a/topological_navigation/launch/topological_navigation.launch
+++ b/topological_navigation/launch/topological_navigation.launch
@@ -1,11 +1,14 @@
 <launch>
 	<!-- declare arg to be passed in -->
-	<arg name="map" default="tmap_II"/> 
+	<arg name="map"/> 
+        <arg name="mon_nav_config_file"  default="" />
 	<arg name="machine" default="localhost" />
 	<arg name="user" default="" />
 
 	<machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="true"/>
 
+ 	<node pkg="monitored_navigation" type="monitored_nav.py" name="monitored_nav" output="screen" args="$(arg mon_nav_config_file)"/> 
+	
 	<node pkg="topological_navigation" type="map_publisher.py" name="topological_map_publisher" args="$(arg map)"/>
  
 	<node pkg="topological_navigation" name="topological_localisation" type="localisation.py" output="screen"/>

--- a/topological_navigation/package.xml
+++ b/topological_navigation/package.xml
@@ -38,6 +38,7 @@
   <run_depend>mongodb_store</run_depend>
   <run_depend>strands_navigation_msgs</run_depend>
   <run_depend>visualization_msgs</run_depend>
+  <run_depend>monitored_navigation</run_depend>
 
 
 


### PR DESCRIPTION
default is monitored_nav without recovery behaviours
