### PR TITLE
dynamic config of goal tolerance

### DIFF
--- a/topological_navigation/scripts/execute_policy_server.py
+++ b/topological_navigation/scripts/execute_policy_server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import math
 import rospy
 import actionlib
 import pymongo
@@ -393,6 +394,7 @@ class PolicyExecutionServer(object):
             if i.name == node :
                 found = True
                 target_pose = i.pose#[0]
+                tolerance=i.xy_goal_tolerance
                 break
         
         if found:
@@ -404,8 +406,12 @@ class PolicyExecutionServer(object):
             self.stat=nav_stats(self.current_node, node, self.topol_map, edg)
             #dt_text=self.stat.get_start_time_str()
 
+            if action in self.move_base_actions and node in self.current_route.source:
+                rospy.set_param("/move_base/NavfnROS/default_tolerance",tolerance/math.sqrt(2))  
+                
             result = self.monitored_navigation(target_pose, action)
-
+            
+            rospy.set_param("/move_base/NavfnROS/default_tolerance",0.0)
 
             self.stat.set_ended(self.current_node)
 


### PR DESCRIPTION
solves #187 

This does what is expected on a high-level, i.e., if there's an obstacle directly on some intermediary waypoints, the global planner creates a plan to get as close to it as possible (within the goal tolerance). Then, once the robot gets into the influence area of that waypoint, it receives a new goal for the next one. 

However, move_base is behaving badly, and once the above happens, many times the robot is not able to plan around the obstacle (even though in general he has space for that...). He then usually backtracks and continues afterwards. Not very smooth, but he ends up going through.

@Jailander please take a look and test. Also, as we discussed, maybe we should remote the xy and yaw tolerances from the topological node defs (as those are local planner related params), and just add a goal_tolerance param. For the current default waypoints, a good tolerance is 0.48
