### PR TITLE
Adding action server to allow scheduling of fremen model construction

### DIFF
--- a/strands_navigation_msgs/CMakeLists.txt
+++ b/strands_navigation_msgs/CMakeLists.txt
@@ -70,6 +70,7 @@ add_action_files(
 	FILES 
 	MonitoredNavigation.action
 	ExecutePolicyMode.action
+	BuildTopPrediction.action
 )
 
 

--- a/strands_navigation_msgs/action/BuildTopPrediction.action
+++ b/strands_navigation_msgs/action/BuildTopPrediction.action
@@ -1,0 +1,7 @@
+#goal definition
+---
+#result definition
+bool success
+---
+#feedback
+string result

--- a/topological_navigation/scripts/topological_prediction.py
+++ b/topological_navigation/scripts/topological_prediction.py
@@ -50,6 +50,7 @@ class TopologicalNavPred(object):
         self.eids = []
         self.unknowns = []
         self.map_received =False
+        action_name = name+'/build_temporal_model'
 
         rospy.Subscriber('/topological_map', TopologicalMap, self.MapCallback)
         
@@ -66,7 +67,7 @@ class TopologicalNavPred(object):
 
         #Creating Action Server
         rospy.loginfo("Creating action server.")
-        self._as = actionlib.SimpleActionServer(name, strands_navigation_msgs.msg.BuildTopPredictionAction, execute_cb = self.BuildCallback, auto_start = False)
+        self._as = actionlib.SimpleActionServer(action_name, strands_navigation_msgs.msg.BuildTopPredictionAction, execute_cb = self.BuildCallback, auto_start = False)
         self._as.register_preempt_callback(self.preemptCallback)
         rospy.loginfo(" ...starting")
         self._as.start()


### PR DESCRIPTION
I am adding an action server to build the fremen models for topological prediction.
Previously these models were only updated when the navigation was launched, so now it is necessary to rebuild these model periodically for long term operation.
Also even though the prediction itself is a service, the building of the models has been made an action server so it can be scheduled. The prediction will remain a service so no changes in other's code are necessary.
This PR does this in  topological_navigation/scripts/topological_prediction.py the changes in other files are necessary for the creation of the action itself.
