### PR TITLE
[topological_navigation] Added the wait_reset_bumper_duration arg to top_nav.launch

### DIFF
--- a/topological_navigation/launch/topological_navigation.launch
+++ b/topological_navigation/launch/topological_navigation.launch
@@ -1,27 +1,30 @@
 <launch>
 	<!-- declare arg to be passed in -->
-	<arg name="map"/> 
-        <arg name="mon_nav_config_file"  default="" />
+	<arg name="map"/>
+	<arg name="mon_nav_config_file"  default="" />
+	<arg name="wait_reset_bumper_duration" default="0.0"/>
 	<arg name="machine" default="localhost" />
 	<arg name="user" default="" />
 
 	<machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="true"/>
 
- 	<node pkg="monitored_navigation" type="monitored_nav.py" name="monitored_nav" output="screen" args="$(arg mon_nav_config_file)"/> 
-	
+ 	<node pkg="monitored_navigation" type="monitored_nav.py" name="monitored_nav" output="screen" args="$(arg mon_nav_config_file)">
+		<param name="wait_reset_bumper_duration" value="$(arg wait_reset_bumper_duration)"/>
+	</node>
+
 	<!-- <node pkg="topological_navigation" type="map_publisher.py" name="topological_map_publisher" args="$(arg map)"/> -->
 	<node pkg="topological_navigation" type="map_manager.py" name="topological_map_manager" args="$(arg map)"/>
- 
-	<node pkg="fremenserver" type="fremenserver" name="fremenserver"/> 
-	
+
+	<node pkg="fremenserver" type="fremenserver" name="fremenserver"/>
+
 	<node pkg="topological_navigation" name="topological_localisation" type="localisation.py" output="screen"/>
 	<node pkg="topological_navigation" name="topological_navigation" type="navigation.py" output="screen"/>
 	<node pkg="topological_navigation" name="execute_policy_server" type="execute_policy_server.py" output="screen"/>
-	
-	<node pkg="topological_navigation" type="visualise_map.py" name="visualise_map" args="$(arg map)"/> 
 
-	<node pkg="topological_navigation" type="travel_time_estimator.py" name="travel_time_estimator"/> 
-	<node pkg="topological_navigation" type="topological_prediction.py" name="topological_prediction"/> 
+	<node pkg="topological_navigation" type="visualise_map.py" name="visualise_map" args="$(arg map)"/>
+
+	<node pkg="topological_navigation" type="travel_time_estimator.py" name="travel_time_estimator"/>
+	<node pkg="topological_navigation" type="topological_prediction.py" name="topological_prediction"/>
 
 
 </launch>


### PR DESCRIPTION
This just adds the parameter in https://github.com/strands-project/strands_recovery_behaviours/pull/55 to allow us to set it from the bringup. Allows to specify the wait time before continuing after the bumper has been released without human help.
