### PR TITLE
If localised by topic assume as current node no matter pose

### DIFF
--- a/topological_navigation/scripts/localisation.py
+++ b/topological_navigation/scripts/localisation.py
@@ -86,11 +86,11 @@ class TopologicalNavLoc(object):
             
             not_loc=True
             if self.loc_by_topic:
-                test_node=get_node(self.tmap, self.loc_by_topic[0])
-                if self.point_in_poly(test_node, msg):
-                    not_loc=False
-                    closeststr=str(self.loc_by_topic[0])
-                    currentstr=str(self.loc_by_topic[0])
+#                test_node=get_node(self.tmap, self.loc_by_topic[0])
+#                if self.point_in_poly(test_node, msg):
+                not_loc=False
+                closeststr=str(self.loc_by_topic[0])
+                currentstr=str(self.loc_by_topic[0])
 
             if not_loc:
                 ind = 0


### PR DESCRIPTION
We have removed the condition of being within the influence area of a node to assume localise by topic, this will have some effects.

If the robot is charging it will assume it is at the charging station no matter where it actually is, this has pros and cons:
One big and important **PRO** is that if localisation is lost at the charging station when the robot tries to move it will try to undock and IF position injection is active it will relocalise, 

On the **CON** side is that the robot will also assume to be at the charging station node no matter where it is as long as it is charging, so it will assume to be at the charging Station even when charging by cable. 
To solve this we thought about using the `/rfid` topic to solve this, but it is less reliable that the charging topic and unlike the  `/battery_state` topic its only being published while its there so if there is no new info on the `/rfid` topic it will keep assuming to be on the charging station, in any case this should not happen and will be added to an issue to solve later.
