### PR TITLE
Rename utility

### DIFF
--- a/topological_utils/scripts/rename_node
+++ b/topological_utils/scripts/rename_node
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+
+"""
+Outputs a list of available topological maps
+"""
+
+from topological_utils.nodes import rename_node
+import sys
+
+if __name__ == "__main__":
+    print "Changing %s[%s] to %s"%(sys.argv[3],sys.argv[1],sys.argv[2]) 
+    try:
+        n, e = rename_node(sys.argv[1], sys.argv[2], sys.argv[3])
+    except Exception, e:
+        print "Failed: ", e.message
+        sys.exit(1)
+    print "Changed ", n, " nodes."
+    print "Changed ", e, " edges."

--- a/topological_utils/scripts/rename_node
+++ b/topological_utils/scripts/rename_node
@@ -8,9 +8,13 @@ from topological_utils.nodes import rename_node
 import sys
 
 if __name__ == "__main__":
-    print "Changing %s[%s] to %s"%(sys.argv[3],sys.argv[1],sys.argv[2]) 
+    if len(sys.argv) != 4:
+        print "Usage: rename_node current_node_name new_node_name tological_map_name)"
+        sys.exit(1)
+    old_name, new_name, map_name = sys.argv[1:]
+    print "Changing %s[%s] to %s"%(map_name, old_name, new_name)
     try:
-        n, e = rename_node(sys.argv[1], sys.argv[2], sys.argv[3])
+        n, e = rename_node(old_name, new_name, map_name)
     except Exception, e:
         print "Failed: ", e.message
         sys.exit(1)

--- a/topological_utils/src/topological_utils/nodes.py
+++ b/topological_utils/src/topological_utils/nodes.py
@@ -1,0 +1,62 @@
+"""
+Provides routines for working with topological map nodes
+"""
+
+from strands_navigation_msgs.msg import TopologicalNode
+from mongodb_store.message_store import MessageStoreProxy
+import queries
+import rospy
+import copy
+
+def rename_node(name, new_name, top_map_name):
+    """
+    Renames a topological map node. All edges will be updated to reflect the change.
+
+    @param name: the current name of the node to be changec
+    @param new_name: the new name to give the node
+    @param top_map_name: the name of the topological map to work with (pointset)
+
+    @return (number of nodes changed, number of edges changed)
+    """
+
+    maps = queries.get_maps()
+    if top_map_name not in maps:
+        raise Exception("Unknown topological map.")
+
+    msg_store = MessageStoreProxy(collection='topological_maps')
+    
+    nodes = msg_store.query(TopologicalNode._type, {}, {'pointset':top_map_name})
+    node_renames = 0
+    edge_changes = 0
+    node_changes = 0
+
+    if name not in nodes:
+        raise Exception("No such node.")
+    if new_name in nodes:
+        raise Exception("New node name already in use.")
+
+    old_metas = []
+    for node, meta in nodes:
+        old_metas.append(copy.deepcopy(meta))
+        if meta["node"] == name:
+            meta["node"] = new_name
+        if node.name == name:
+            node.name = new_name
+            node_renames += 1
+            if node_renames > 1:
+                raise Exception("More than one node has the same name!")
+        for edge in node.edges:
+            if edge.node == name:
+                edge.node = new_name
+            if edge.edge_id.find(name) > 0:
+                edge.edge_id = edge.edge_id.replace(name, new_name)
+                edge_changes += 1
+            
+    # Save the changed nodes
+    for ((node, meta), old_meta) in zip(nodes, old_metas):
+        changed = msg_store.update(node, meta, {'name':old_meta['node'],
+                                                'pointset':meta['pointset']})
+        if changed.success:
+            node_changes += 1
+
+    return (node_changes, edge_changes)

--- a/topological_utils/src/topological_utils/nodes.py
+++ b/topological_utils/src/topological_utils/nodes.py
@@ -49,7 +49,7 @@ def rename_node(name, new_name, top_map_name):
         for edge in node.edges:
             if edge.node == name:
                 edge.node = new_name
-            if edge.edge_id.find(name) > 0:
+            if edge.edge_id.find(name) > -1:
                 edge.edge_id = edge.edge_id.replace(name, new_name)
                 edge_changes += 1
             

--- a/topological_utils/src/topological_utils/nodes.py
+++ b/topological_utils/src/topological_utils/nodes.py
@@ -26,13 +26,14 @@ def rename_node(name, new_name, top_map_name):
     msg_store = MessageStoreProxy(collection='topological_maps')
     
     nodes = msg_store.query(TopologicalNode._type, {}, {'pointset':top_map_name})
+    node_names = [node.name for node,meta in nodes]
     node_renames = 0
     edge_changes = 0
     node_changes = 0
 
-    if name not in nodes:
+    if name not in node_names:
         raise Exception("No such node.")
-    if new_name in nodes:
+    if new_name in node_names:
         raise Exception("New node name already in use.")
 
     old_metas = []


### PR DESCRIPTION
This adds a utility to easily rename nodes. The commits are wrongly labeled as authored by @RaresAmbrus because he is setup as global on Bob. If really needed I could look at rewriting this history, but I don't think it matters for this unless it is really easy to do for multiple commits...

Of course, this might be already present in `migrate.py` ;-)
