### PR TITLE
Adding navigation tests using obstacles that are not in the SLAM map

### DIFF
--- a/topological_navigation/tests/README.md
+++ b/topological_navigation/tests/README.md
@@ -79,13 +79,13 @@ The topological maps used for the tests presented here can be found in `strands_
  * `mb_test9`: Traverse a 1m wide straight corridor.
  * `mb_test10`: Traverse a 1m wide l-shaped corridor.
  * `mb_test11`: Wheelchair blocking an intermediate node in open space.
- * `mb_test12`: Wheelchair blocking final node in open space.
+ * `mb_test12`: Wheelchair blocking final node in open space. Graceful fail has to be tru to pass this test as the node itself can never be reached precisely.
  * `mb_test13`: Human blocking an intermediate node in open space.
- * `mb_test14`: Human blocking final node in open space.
+ * `mb_test14`: Human blocking final node in open space. Graceful fail has to be tru to pass this test as the node itself can never be reached precisely.
  * `mb_test15`: Non-SLAM map chairs on one side of 2m wide l-shaped corridor.
  * `mb_test16`: Non-SLAM map wheelchairs on one side of 2m wide l-shaped corridor.
- * `mb_test17`: Non-SLAM map wheelchairs block 2m wide l-shaped corridor after intermediate waypoint.
- * `mb_test18`: Non-SLAM map static humans block 2m wide l-shaped corridor after intermediate waypoint.
+ * `mb_test17`: Non-SLAM map wheelchairs block 2m wide l-shaped corridor after intermediate waypoint. Graceful fail has to be tru to pass this test as the node itself can never be reached.
+ * `mb_test18`: Non-SLAM map static humans block 2m wide l-shaped corridor after intermediate waypoint. Graceful fail has to be tru to pass this test as the node itself can never be reached.
 
 **Dynamic**
 
@@ -137,7 +137,7 @@ The topological map used for each test has to be a different one and the nodes h
 
 **Creating scnearios with obstacles that are not in the SLAM map**
 
-For this purpose, there are `Chair`s, `OfficeChair`s, `WheelChair`s, and `StaticHuman`s that can be positioned via topological nodes. Each object has 10 instances so you can only use 10 of any single object. The Objects are positioned according to topological nodes following a naming scheme: `ObstacleStaticHuman1` for example positions a static human model on this node. `Obstacle` is the `obstacle_node_prefix`  defined in the `conf/scneario_server.yaml`, `StaticHuman` is the identifier of the obstacle type (if this omitted, a `Chair` will be used), and `1` is just an arbitrary number to make the node name unique. When creating the topoligocal map, make sure that all edges from and to obstacle nodes are removed. Additionally, the nodes need to define a `localise_by_topic` json string so the robot will never localise itself based on these nodes. In the current simulation, we use the charging topic, because the robot will never charge and hence never localise itself at these nodes and the topic has to exist, otherwise topological navigation fails. Example node:
+For this purpose, there are `Chair`s, `OfficeChair`s, `WheelChair`s, and `StaticHuman`s present in the current test environment that can be positioned via topological nodes. The exact obstacle types are defined in the `conf/scenario_server.yaml` under `obstacle_types`; The names used have to be the variable name of the obstacle in the morse environment. Obstacle types have to be lower case, node names can be camel case to enhance readability. Currently, in the test environment, each object has 10 instances so you can only use 10 of any single object. The Objects are positioned according to topological nodes following a naming scheme: `ObstacleStaticHuman1` for example positions a static human model on this node. `Obstacle` is the `obstacle_node_prefix`  defined in the `conf/scneario_server.yaml`, `StaticHuman` is the identifier of the obstacle type (if this omitted, an arbitrary object will be used), and `1` is just an arbitrary number to make the node name unique. When creating the topoligocal map, make sure that all edges from and to obstacle nodes are removed. Additionally, the nodes need to define a `localise_by_topic` json string so the robot will never localise itself based on these nodes. In the current simulation, we use the charging topic, because the robot will never charge and hence never localise itself at these nodes. We have to use an existing topic otherwise topological navigation fails. Example node:
 
 ```
 - meta:

--- a/topological_navigation/tests/README.md
+++ b/topological_navigation/tests/README.md
@@ -80,10 +80,12 @@ The topological maps used for the tests presented here can be found in `strands_
  * `mb_test10`: Traverse a 1m wide l-shaped corridor.
  * `mb_test11`: Wheelchair blocking an intermediate node in open space.
  * `mb_test12`: Wheelchair blocking final node in open space.
- * `mb_test13`: Non-SLAM map chairs on one side of 2m wide l-shaped corridor.
- * `mb_test14`: Non-SLAM map wheelchairs on one side of 2m wide l-shaped corridor.
- * `mb_test15`: Non-SLAM map wheelchairs block 2m wide l-shaped corridor after intermediate waypoint.
- * `mb_test16`: Non-SLAM map static humans block 2m wide l-shaped corridor after intermediate waypoint.
+ * `mb_test13`: Human blocking an intermediate node in open space.
+ * `mb_test14`: Human blocking final node in open space.
+ * `mb_test15`: Non-SLAM map chairs on one side of 2m wide l-shaped corridor.
+ * `mb_test16`: Non-SLAM map wheelchairs on one side of 2m wide l-shaped corridor.
+ * `mb_test17`: Non-SLAM map wheelchairs block 2m wide l-shaped corridor after intermediate waypoint.
+ * `mb_test18`: Non-SLAM map static humans block 2m wide l-shaped corridor after intermediate waypoint.
 
 **Dynamic**
 

--- a/topological_navigation/tests/README.md
+++ b/topological_navigation/tests/README.md
@@ -65,17 +65,25 @@ The topological maps used for the tests presented here can be found in `strands_
 
 **Static:**
 
-* `mb_test0`: Traversing a 2m wide l-shaped corridor.
-* `mb_test1`: The robot starting 10cm away from a wall facing it straight on (0 degrees)
-* `mb_test2`: The robot starting 10cm away from a wall facing it turned to the left (-45 degrees)
-* `mb_test3`: The robot starting 10cm away from a wall facing it turned to the right (+45 degrees)
-* `mb_test4`: Traversing a 1.55m wide straight corridor with .55m wide chairs on one side.
-* `mb_test5`: Traversing a 2.1m wide straight corridor with .55m wide chairs on both sides.
-* `mb_test6`: Cross a 80cm wide door.
-* `mb_test7`: Cross a 70cm wide door.
-* `mb_test8`: The robot is trapped in a corner and has to reach a goal behind it.
-* `mb_test9`: Traverse a 1m wide straight corridor.
-* `mb_test10`: Traverse a 1m wide l-shaped corridor.
+* System critical:
+ * `mb_test0`: Traversing a 2m wide l-shaped corridor.
+* Supplementary:
+ * `mb_test1`: The robot starting 10cm away from a wall facing it straight on (0 degrees)
+ * `mb_test2`: The robot starting 10cm away from a wall facing it turned to the left (-45 degrees)
+ * `mb_test3`: The robot starting 10cm away from a wall facing it turned to the right (+45 degrees)
+ * `mb_test4`: Traversing a 1.55m wide straight corridor with .55m wide chairs on one side.
+ * `mb_test5`: Traversing a 2.1m wide straight corridor with .55m wide chairs on both sides.
+ * `mb_test6`: Cross a 80cm wide door.
+ * `mb_test7`: Cross a 70cm wide door.
+ * `mb_test8`: The robot is trapped in a corner and has to reach a goal behind it.
+ * `mb_test9`: Traverse a 1m wide straight corridor.
+ * `mb_test10`: Traverse a 1m wide l-shaped corridor.
+ * `mb_test11`: Wheelchair blocking an intermediate node in open space.
+ * `mb_test12`: Wheelchair blocking final node in open space.
+ * `mb_test13`: Non-SLAM map chairs on one side of 2m wide l-shaped corridor.
+ * `mb_test14`: Non-SLAM map wheelchairs on one side of 2m wide l-shaped corridor.
+ * `mb_test15`: Non-SLAM map wheelchairs block 2m wide l-shaped corridor after intermediate waypoint.
+ * `mb_test16`: Non-SLAM map static humans block 2m wide l-shaped corridor after intermediate waypoint.
 
 **Dynamic**
 
@@ -124,4 +132,38 @@ The topological map used for each test has to be a different one and the nodes h
 1. Rename the start and end node to `Start` and `End` using `rosrun topological_utils rename_node <old_name> <new_name> <map_name>`
 1. This map can now be loaded with `/scenario_server/load <map_name>`
 
+
+**Creating scnearios with obstacles that are not in the SLAM map**
+
+For this purpose, there are `Chair`s, `OfficeChair`s, `WheelChair`s, and `StaticHuman`s that can be positioned via topological nodes. Each object has 10 instances so you can only use 10 of any single object. The Objects are positioned according to topological nodes following a naming scheme: `ObstacleStaticHuman1` for example positions a static human model on this node. `Obstacle` is the `obstacle_node_prefix`  defined in the `conf/scneario_server.yaml`, `StaticHuman` is the identifier of the obstacle type (if this omitted, a `Chair` will be used), and `1` is just an arbitrary number to make the node name unique. When creating the topoligocal map, make sure that all edges from and to obstacle nodes are removed. Additionally, the nodes need to define a `localise_by_topic` json string so the robot will never localise itself based on these nodes. In the current simulation, we use the charging topic, because the robot will never charge and hence never localise itself at these nodes and the topic has to exist, otherwise topological navigation fails. Example node:
+
+```
+- meta:
+     map: mb_arena
+     node: ObstacleStaticHuman1
+     pointset: mb_test16
+   node:
+     edges: []
+     localise_by_topic: '{"topic": "/battery_state", "field": "charging", "val": true}'
+     map: mb_arena
+     name: ObstacleStaticHuman1
+     pointset: mb_test16
+     pose:
+       orientation:
+         w: 0.816770076752
+         ...
+       position:
+        x: -4.58532047272
+        ...
+     verts:
+     - x: 0.689999997616
+       y: 0.287000000477
+     ...
+     xy_goal_tolerance: 0.3
+     yaw_goal_tolerance: 0.1
+```
+
+Where the important bit is the `localise_by_topic: '{"topic": "/battery_state", "field": "charging", "val": true}'` entry.
+
+After the map has been loaded the obstacles will be spawned at (or better moved to) the respective nodes before the robot starts navigating. Before each test the arena is cleared to make sure that no obstacles linger.
 

--- a/topological_navigation/tests/conf/scenario_server.yaml
+++ b/topological_navigation/tests/conf/scenario_server.yaml
@@ -1,6 +1,10 @@
 robot_start_node: Start
 robot_goal_node: End
-human_start_node: HumanStart
 obstacle_node_prefix: Obstacle
+obstacle_types:
+    - chair
+    - officechair
+    - wheelchair
+    - statichuman
 success_metrics:
     nav_timeout: 60.0 # 0 for inf

--- a/topological_navigation/tests/conf/scenario_server.yaml
+++ b/topological_navigation/tests/conf/scenario_server.yaml
@@ -1,4 +1,6 @@
 robot_start_node: Start
 robot_goal_node: End
+human_start_node: HumanStart
+obstacle_node_prefix: Obstacle
 success_metrics:
     nav_timeout: 60.0 # 0 for inf

--- a/topological_navigation/tests/navigation_scenarios.test
+++ b/topological_navigation/tests/navigation_scenarios.test
@@ -10,7 +10,7 @@
     </include>
 
     <include file="$(find strands_morse)/mba/launch/move_base_arena.launch">
-      <arg name="env" value="mba_fast"/>
+      <arg name="env" value="mba_test"/>
     </include>
     <include file="$(find strands_morse)/mba/launch/move_base_arena_nav.launch"/>
 

--- a/topological_navigation/tests/scenario_server.py
+++ b/topological_navigation/tests/scenario_server.py
@@ -12,7 +12,7 @@ from std_srvs.srv import Empty, EmptyResponse
 from std_msgs.msg import Header, String
 import yaml
 import numpy as np
-from geometry_msgs.msg import PoseWithCovarianceStamped, Pose, PoseStamped
+from geometry_msgs.msg import PoseWithCovarianceStamped, Pose, PoseStamped, Point
 import actionlib
 import actionlib_msgs
 from topological_navigation.msg import GotoNodeAction, GotoNodeGoal
@@ -22,13 +22,17 @@ from roslib.packages import find_resource
 import time
 from strands_navigation_msgs.srv import GetTopologicalMap, GetTopologicalMapRequest
 from tf import TransformListener
-from tf.transformations import euler_from_quaternion
+import tf.transformations as trans
 from topological_navigation.load_maps_from_yaml import YamlMapLoader
 from scitos_teleop.msg import action_buttons
 from scitos_msgs.srv import EnableMotors, ResetBarrierStop, ResetMotorStop
+import subprocess
+import os
+from threading import Thread
 
 HOST = 'localhost'
 PORT = 4000
+PKG = "topological_navigation"
 
 
 class ScenarioServer(object):
@@ -36,22 +40,25 @@ class ScenarioServer(object):
     _loaded = False
     _robot_poses = []
     _distances = [0,0]
+    _obstacle_types = ["chair", "officechair", "wheelchair", "statichuman"]
 
     def __init__(self, name):
         rospy.loginfo("Starting scenario server")
-        robot = rospy.get_param("~robot", False)
+        self.robot = rospy.get_param("~robot", False)
         conf_file = find_resource("topological_navigation", "scenario_server.yaml")[0]
         rospy.loginfo("Reading config file: %s ..." % conf_file)
         with open(conf_file,'r') as f:
             conf = yaml.load(f)
         self._robot_start_node = conf["robot_start_node"]
         self._robot_goal_node = conf["robot_goal_node"]
+        self._human_start_node = conf["human_start_node"]
+        self._obstacle_node_prefix = conf["obstacle_node_prefix"]
         self._timeout = conf["success_metrics"]["nav_timeout"]
         rospy.loginfo(" ... done")
         self._insert_maps()
         self.tf = TransformListener()
         rospy.Service("~load", LoadTopoNavTestScenario, self.load_scenario)
-        self.reset_pose = self.reset_pose_robot if robot else self.reset_pose_sim
+        self.reset_pose = self.reset_pose_robot if self.robot else self.reset_pose_sim
         rospy.Service("~reset", Empty, self.reset)
         rospy.Service("~start", RunTopoNavTestScenario, self.start)
         rospy.loginfo("All done")
@@ -124,10 +131,7 @@ class ScenarioServer(object):
         new_pose.pose.orientation.w, new_pose.pose.orientation.x, new_pose.pose.orientation.y, new_pose.pose.orientation.z)
 
     def robot_start_dist(self, msg):
-        self._distances[0] = self.get_distance_travelled([msg, self._robot_start_pose.pose])[0]
-        q1 = (msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w)
-        q2 = (self._robot_start_pose.pose.orientation.x, self._robot_start_pose.pose.orientation.y, self._robot_start_pose.pose.orientation.z, self._robot_start_pose.pose.orientation.w)
-        self._distances[1] = (euler_from_quaternion(q1)[2] - euler_from_quaternion(q2)[2]) * 180/np.pi
+        self._distances = self._get_pose_distance(msg, self._robot_start_pose.pose)
 
     def reset_pose_robot(self):
         rospy.loginfo("Enabling freerun ...")
@@ -174,37 +178,100 @@ class ScenarioServer(object):
             rospy.logwarn(e)
         rospy.loginfo("... enabled and reset")
 
+    def _send_socket(self, sock, agent, pose):
+        sock.send(
+            self._get_set_object_pose_command(
+                agent,
+                self._id,
+                pose
+            )
+        )
+        res = sock.recv(4096)
+        self._id += 1
+        if "FAILURE" in res:
+            raise Exception(res)
+
+    def _get_quaternion_distance(self, q1, q2):
+        q1 = (q1.x, q1.y, q1.z, q1.w)
+        q2 = (q2.x, q2.y, q2.z, q2.w)
+        return (trans.euler_from_quaternion(q1)[2] - trans.euler_from_quaternion(q2)[2]) * 180/np.pi
+
+    def _get_euclidean_distance(self, p1, p2):
+        return np.sqrt(np.power(p2.x - p1.x, 2) + np.power(p2.y - p1.y, 2))
+
+    def _get_pose_distance(self, p1, p2):
+        e = self._get_euclidean_distance(p1.position, p2.position)
+        q = self._get_quaternion_distance(p1.orientation, p2.orientation)
+        return e, q
+
     def reset_pose_sim(self):
         sock = self._connect_port(PORT)
         if not sock:
             raise Exception("Could not create socket connection to morse")
 
-        sock.send(
-            self._get_set_object_pose_command(
-                "robot",
-                self._id,
-                self._robot_start_pose
-            )
+        # Clean up whole scene
+        # Create pose outside of map
+        clear_pose = PoseStamped(
+            header=Header(stamp=rospy.Time.now(), frame_id="/map"),
+            pose=Pose(position=Point(x=20, y=20, z=0.01))
         )
-        self._id += 1
+
+        # Moving obstacles and human to clear_pose
+        for obstacle in self._obstacle_types:
+            for idx in range(10):
+                self._send_socket(sock, obstacle+str(idx), clear_pose)
+        self._send_socket(sock, "human", clear_pose) # Human will start falling but this is no problem.
+
+        # Setting robot, human and obstacles to correct position
+        self._send_socket(sock, "robot", self._robot_start_pose)
+
+        if self._human_start_pose != None:
+            self._send_socket(sock, "human", self._human_start_pose)
+        else:
+            rospy.logwarn("No node named '%s' found in map. Assuming test without human." % self._human_start_node)
+
+        if len(self._obstacle_poses) > 0:
+            for idx, d in enumerate(self._obstacle_poses):
+                try:
+                    obstacle = max([x for x in self._obstacle_types if x in d["name"]], key=len)
+                except ValueError:
+                    rospy.logwarn("No obstacle specified for obstacle node '%s', will use '%s'." % (d["name"], self._obstacle_types[0]))
+                    obstacle = self._obstacle_types[0]
+                rospy.loginfo("Adding obstacle %s%i" % (obstacle,idx))
+                self._send_socket(sock, obstacle+str(idx), d["pose"])
+        else:
+            rospy.logwarn("No nodes starting with '%s' found in map. Assuming test without obstacles." % self._obstacle_node_prefix)
 
         sock.close()
+
+        while not rospy.is_shutdown():
+            rpose = rospy.wait_for_message("/robot_pose", Pose)
+            rospy.loginfo("Setting initial amcl pose ...")
+            self._init_nav(self._robot_start_pose)
+            dist = self._get_pose_distance(rpose, self._robot_start_pose.pose)
+            if dist[0] < 0.1 and dist[1] < 10:
+                break
+            rospy.sleep(0.2)
+#            self._robot_start_pose.header.stamp = rospy.Time.now()
+        rospy.loginfo(" ... pose set.")
 
     def reset(self, req):
         if not self._loaded:
             rospy.logfatal("No scenario loaded!")
             return EmptyResponse()
 
+        self.client.cancel_all_goals()
+
         rospy.loginfo("Resetting robot position...")
 
         self.reset_pose()
 
-        self._init_nav(self._robot_start_pose)
         self._clear_costmaps()
         rospy.loginfo("... reset successful")
         return EmptyResponse()
 
     def graceful_fail(self):
+        res = False
         closest_node = rospy.wait_for_message("/closest_node", String).data
         rospy.loginfo("Closest node: %s" % closest_node)
         if closest_node != self._robot_start_node:
@@ -214,7 +281,8 @@ class ScenarioServer(object):
             policy = s(self._robot_start_node)
             self.client.send_goal(ExecutePolicyModeGoal(route=policy.route))
             self.client.wait_for_result(timeout=rospy.Duration(self._timeout))
-            return self.client.get_state() == actionlib_msgs.msg.GoalStatus.SUCCEEDED
+            res = self.client.get_state() == actionlib_msgs.msg.GoalStatus.SUCCEEDED
+            self.client.cancel_all_goals()
         else:
             rospy.loginfo("Using topo nav from %s to %s" % (closest_node, self._robot_start_node))
             rospy.loginfo("Starting topo nav client...")
@@ -223,10 +291,29 @@ class ScenarioServer(object):
             rospy.loginfo(" ... done")
             client.send_goal(GotoNodeGoal(target=self._robot_start_node))
             client.wait_for_result(timeout=rospy.Duration(self._timeout))
-            return client.get_state() == actionlib_msgs.msg.GoalStatus.SUCCEEDED
+            res = client.get_state() == actionlib_msgs.msg.GoalStatus.SUCCEEDED
+            client.cancel_all_goals()
+        return res
+
+    def play_human_bag(self, bag):
+        try:
+            bag_file = find_resource(PKG, bag)[0]
+        except IndexError:
+            rospy.logwarn("No bag for human movement found, assuming static test.")
+            return
+
+        rospy.loginfo("Found bag file: '%s'. Spawning human.")
+        pass # Spawn human somewhere
+        rospy.loginfo("Starting playback of human movement ...")
+        with open(os.devnull, 'w') as FNULL:
+            p = subprocess.Popen("rosbag play "+bag_file, stdin=subprocess.PIPE, shell=True, stdout=FNULL)
+            while p.poll() == None:
+                rospy.sleep(1)
+        rospy.loginfo(" ... playback of human movement finished")
 
     def start(self, req):
         rospy.loginfo("Starting test ...")
+        human_thread = Thread(target=self.play_human_bag, args=(self.pointset+".bag",))
         if not self._loaded:
             rospy.logfatal("No scenario loaded!")
             return RunTopoNavTestScenarioResponse(False, False)
@@ -235,18 +322,22 @@ class ScenarioServer(object):
         grace_res = False
         sub = rospy.Subscriber("/robot_pose", Pose, self.robot_callback)
         rospy.loginfo("Sending goal to policy execution ...")
+        print self._policy.route
         self.client.send_goal(ExecutePolicyModeGoal(route=self._policy.route))
+        human_thread.start()
         t = time.time()
         rospy.loginfo("... waiting for result ...")
+        print self._timeout
         self.client.wait_for_result(timeout=rospy.Duration(self._timeout))
         elapsed = time.time() - t
         res = self.client.get_state() == actionlib_msgs.msg.GoalStatus.SUCCEEDED
         rospy.loginfo("... policy execution finished")
         self.client.cancel_all_goals()
         if not res:
-            rospy.loginfo("Attemting graceful death ...")
+            rospy.loginfo("Attempting graceful death ...")
             grace_res = self.graceful_fail()
             rospy.loginfo("... dead")
+        human_thread.join()
         sub.unregister()
         sub = None
         distance = self.get_distance_travelled(self._robot_poses)
@@ -264,10 +355,7 @@ class ScenarioServer(object):
     def get_distance_travelled(self, poses):
         distance = 0.0
         for idx in range(len(poses))[1:]:
-            distance += np.sqrt(
-                [((poses[idx].position.x - poses[idx-1].position.x)**2) \
-                + ((poses[idx].position.y - poses[idx-1].position.y)**2)]
-            )
+            distance += self._get_euclidean_distance(poses[idx].position, poses[idx-1].position)
         return distance
 
     def load_scenario(self, req):
@@ -276,16 +364,33 @@ class ScenarioServer(object):
         s.wait_for_service()
         topo_map = s(GetTopologicalMapRequest(pointset=req.pointset)).map
 
+        self.pointset = req.pointset
+
         self._robot_start_pose = None
+        self._human_start_pose = None
+        self._obstacle_poses = []
         found_end_node = False
         for node in topo_map.nodes:
             if node.name == self._robot_start_node:
                 self._robot_start_pose = PoseStamped(
-                        header=Header(stamp=rospy.Time.now(), frame_id="/map"),
-                        pose=node.pose
+                    header=Header(stamp=rospy.Time.now(), frame_id="/map"),
+                    pose=node.pose
                 )
             elif node.name == self._robot_goal_node:
                 found_end_node = True
+            elif node.name == self._human_start_node:
+                self._human_start_pose = PoseStamped(
+                    header=Header(stamp=rospy.Time.now(), frame_id="/map"),
+                    pose=node.pose
+                )
+            elif node.name.startswith(self._obstacle_node_prefix):
+                self._obstacle_poses.append({
+                    "name": node.name.lower(),
+                    "pose": PoseStamped(
+                        header=Header(stamp=rospy.Time.now(), frame_id="/map"),
+                        pose=node.pose
+                    )
+                })
 
         if self._robot_start_pose == None:
             raise Exception("Topological map '%s' does not contain start node '%s'." % (req.pointset, self._robot_start_node))

--- a/topological_navigation/tests/topological_navigation_tester_critical.py
+++ b/topological_navigation/tests/topological_navigation_tester_critical.py
@@ -9,7 +9,7 @@ PKG = 'topological_navigation'
 
 
 class TestTopologicalNavigation(unittest.TestCase):
-    _map_names = ['mb_test0', 'mb_test1', 'mb_test2', 'mb_test3', 'mb_test4', 'mb_test5', 'mb_test6', 'mb_test7', 'mb_test8', 'mb_test9', 'mb_test10']
+    _map_name = 'mb_test'
 
     def __init__(self, *args):
         super(self.__class__, self).__init__(*args)
@@ -29,7 +29,7 @@ class TestTopologicalNavigation(unittest.TestCase):
         return res
 
     def test_static_l_shaped_corridor_2m(self):
-        res = self._run(self._map_names[0])
+        res = self._run(self._map_name+str(0))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 

--- a/topological_navigation/tests/topological_navigation_tester_supplementary.py
+++ b/topological_navigation/tests/topological_navigation_tester_supplementary.py
@@ -78,33 +78,43 @@ class TestTopologicalNavigation(unittest.TestCase):
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
-    def test_static_obstacle_on_intermediate_point(self):
+    def test_static_wheelchair_on_intermediate_point(self):
         res = self._run(self._map_name+str(11))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
-    def test_static_obstacle_on_end_point(self):
+    def test_static_wheelchair_on_end_point(self):
         res = self._run(self._map_name+str(12))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
-    def test_static_chairs_on_one_side_of_corridor(self):
+    def test_static_human_on_intermediate_point(self):
         res = self._run(self._map_name+str(13))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
-    def test_static_wheelchairs_on_one_side_of_corridor(self):
+    def test_static_human_on_end_point(self):
         res = self._run(self._map_name+str(14))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
-    def test_static_corridor_blocked_by_wheelchairs(self):
+    def test_static_chairs_on_one_side_of_corridor(self):
         res = self._run(self._map_name+str(15))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
-    def test_static_corridor_blocked_by_humans(self):
+    def test_static_wheelchairs_on_one_side_of_corridor(self):
         res = self._run(self._map_name+str(16))
+        rospy.loginfo(res)
+        self.assertTrue(res.nav_success)
+
+    def test_static_corridor_blocked_by_wheelchairs(self):
+        res = self._run(self._map_name+str(17))
+        rospy.loginfo(res)
+        self.assertTrue(res.nav_success)
+
+    def test_static_corridor_blocked_by_humans(self):
+        res = self._run(self._map_name+str(18))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 

--- a/topological_navigation/tests/topological_navigation_tester_supplementary.py
+++ b/topological_navigation/tests/topological_navigation_tester_supplementary.py
@@ -86,7 +86,7 @@ class TestTopologicalNavigation(unittest.TestCase):
     def test_static_wheelchair_on_end_point(self):
         res = self._run(self._map_name+str(12))
         rospy.loginfo(res)
-        self.assertTrue(res.nav_success)
+        self.assertTrue(res.graceful_fail)  # Cannot reach final node
 
     def test_static_human_on_intermediate_point(self):
         res = self._run(self._map_name+str(13))
@@ -96,7 +96,7 @@ class TestTopologicalNavigation(unittest.TestCase):
     def test_static_human_on_end_point(self):
         res = self._run(self._map_name+str(14))
         rospy.loginfo(res)
-        self.assertTrue(res.nav_success)
+        self.assertTrue(res.graceful_fail)  # Cannot reach final node
 
     def test_static_chairs_on_one_side_of_corridor(self):
         res = self._run(self._map_name+str(15))
@@ -111,12 +111,12 @@ class TestTopologicalNavigation(unittest.TestCase):
     def test_static_corridor_blocked_by_wheelchairs(self):
         res = self._run(self._map_name+str(17))
         rospy.loginfo(res)
-        self.assertTrue(res.nav_success)
+        self.assertTrue(res.graceful_fail) # Cannot reach final node
 
     def test_static_corridor_blocked_by_humans(self):
         res = self._run(self._map_name+str(18))
         rospy.loginfo(res)
-        self.assertTrue(res.nav_success)
+        self.assertTrue(res.graceful_fail) # Cannot reach final node
 
 
 if __name__ == '__main__':

--- a/topological_navigation/tests/topological_navigation_tester_supplementary.py
+++ b/topological_navigation/tests/topological_navigation_tester_supplementary.py
@@ -9,7 +9,7 @@ PKG = 'topological_navigation'
 
 
 class TestTopologicalNavigation(unittest.TestCase):
-    _map_names = ['mb_test0', 'mb_test1', 'mb_test2', 'mb_test3', 'mb_test4', 'mb_test5', 'mb_test6', 'mb_test7', 'mb_test8', 'mb_test9', 'mb_test10']
+    _map_name = 'mb_test'
 
     def __init__(self, *args):
         super(self.__class__, self).__init__(*args)
@@ -29,52 +29,82 @@ class TestTopologicalNavigation(unittest.TestCase):
         return res
 
     def test_static_facing_wall_1cm_distance_0_degrees_goal_behind(self):
-        res = self._run(self._map_names[1])
+        res = self._run(self._map_name+str(1))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
     def test_static_facing_wall_1cm_distance_minus_45_degrees_goal_behind(self):
-        res = self._run(self._map_names[2])
+        res = self._run(self._map_name+str(2))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
     def test_static_facing_wall_1cm_distance_plus_45_degrees_goal_behind(self):
-        res = self._run(self._map_names[3])
+        res = self._run(self._map_name+str(3))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
     def test_static_155cm_corridor_with_55cm_chairs_on_one_side(self):
-        res = self._run(self._map_names[4])
+        res = self._run(self._map_name+str(4))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
     def test_static_210cm_corridor_with_55cm_chairs_on_both_sides(self):
-        res = self._run(self._map_names[5])
+        res = self._run(self._map_name+str(5))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
     def test_static_80cm_wide_door(self):
-        res = self._run(self._map_names[6])
+        res = self._run(self._map_name+str(6))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
     def test_static_70cm_wide_door(self):
-        res = self._run(self._map_names[7])
+        res = self._run(self._map_name+str(7))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
     def test_static_trapped_in_corner(self):
-        res = self._run(self._map_names[8])
+        res = self._run(self._map_name+str(8))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
     def test_static_1m_striaght_corridor(self):
-        res = self._run(self._map_names[9])
+        res = self._run(self._map_name+str(9))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
     def test_static_1m_l_shaped_corridor(self):
-        res = self._run(self._map_names[10])
+        res = self._run(self._map_name+str(10))
+        rospy.loginfo(res)
+        self.assertTrue(res.nav_success)
+
+    def test_static_obstacle_on_intermediate_point(self):
+        res = self._run(self._map_name+str(11))
+        rospy.loginfo(res)
+        self.assertTrue(res.nav_success)
+
+    def test_static_obstacle_on_end_point(self):
+        res = self._run(self._map_name+str(12))
+        rospy.loginfo(res)
+        self.assertTrue(res.nav_success)
+
+    def test_static_chairs_on_one_side_of_corridor(self):
+        res = self._run(self._map_name+str(13))
+        rospy.loginfo(res)
+        self.assertTrue(res.nav_success)
+
+    def test_static_wheelchairs_on_one_side_of_corridor(self):
+        res = self._run(self._map_name+str(14))
+        rospy.loginfo(res)
+        self.assertTrue(res.nav_success)
+
+    def test_static_corridor_blocked_by_wheelchairs(self):
+        res = self._run(self._map_name+str(15))
+        rospy.loginfo(res)
+        self.assertTrue(res.nav_success)
+
+    def test_static_corridor_blocked_by_humans(self):
+        res = self._run(self._map_name+str(16))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 


### PR DESCRIPTION
To allow for a more flexible static test set-up, this new functionality adds tests that use obstacles:
- a standing human model
- a wheelchair
- an office chair
- a regular chair

and adds them to the mba environment. This is achieved using the topological map. For a detailed description, see README file.

**Brief description:**
A node in the map called `ObstacleHumanStatic1` will add a standing human model with the given orientation and position to the environment before running the test. This way you can add obstacles that are not in the SLAM map. Decomposing the name, `Obstacle` is the prefix for obstacle nodes that can be defined in the `tests/conf/scenario_server.yaml` and `HumanStatic` is one of the obstacle types that is defined in the same file, the `1` is just to make the name unique. There are currently 10 instances of every object which can be used. The obstacle nodes should not have any edges and have to use localise by topic so the robot never localises at one of the nodes. See README for more details on how to create them.

Added tests:
- `mb_test11`: Wheelchair blocking an intermediate node in open space.
- `mb_test12`: Wheelchair blocking final node in open space. Graceful fail has to be tru to pass this test as the node itself can never be reached precisely.
- `mb_test13`: Human blocking an intermediate node in open space.
- `mb_test14`: Human blocking final node in open space. Graceful fail has to be tru to pass this test as the node itself can never be reached precisely.
- `mb_test15`: Non-SLAM map chairs on one side of 2m wide l-shaped corridor.
- `mb_test16`: Non-SLAM map wheelchairs on one side of 2m wide l-shaped corridor.
- `mb_test17`: Non-SLAM map wheelchairs block 2m wide l-shaped corridor after intermediate waypoint. Graceful fail has to be tru to pass this test as the node itself can never be reached.
- `mb_test18`: Non-SLAM map static humans block 2m wide l-shaped corridor after intermediate waypoint. Graceful fail has to be tru to pass this test as the node itself can never be reached.

All of these are run when  starting the supplementary test file.

**Bug fix**

The scenario server now actually waits for morse to report the result of moving the robot and or obstacles.

**Test results**

for some of the new tests where the final node is blocked or the way if cut off before reaching the final node, the test will pass when the robot fails gracefully, i.e. notices that it cannot reach and fails, then trying to go back to the start.
