### PR TITLE
Impossible tests now require the navigation to fail on its own accord

### DIFF
--- a/strands_navigation_msgs/srv/RunTopoNavTestScenario.srv
+++ b/strands_navigation_msgs/srv/RunTopoNavTestScenario.srv
@@ -1,5 +1,6 @@
 ---
 bool nav_success
+bool nav_timeout
 bool graceful_fail
 bool human_success
 float64 min_distance_to_human

--- a/topological_navigation/tests/scenario_server.py
+++ b/topological_navigation/tests/scenario_server.py
@@ -301,7 +301,7 @@ class ScenarioServer(object):
         t = time.time()
         rospy.loginfo("... waiting for result ...")
         print self._timeout
-        self.client.wait_for_result(timeout=rospy.Duration(self._timeout))
+        nav_timeout = not self.client.wait_for_result(timeout=rospy.Duration(self._timeout))
         elapsed = time.time() - t
         res = self.client.get_state() == actionlib_msgs.msg.GoalStatus.SUCCEEDED
         rospy.loginfo("... policy execution finished")
@@ -316,6 +316,7 @@ class ScenarioServer(object):
         rospy.loginfo("... test done")
         return RunTopoNavTestScenarioResponse(
             nav_success=res,
+            nav_timeout=nav_timeout,
             graceful_fail=grace_res,
             human_success=False,
             min_distance_to_human=0,

--- a/topological_navigation/tests/topological_navigation_tester_supplementary.py
+++ b/topological_navigation/tests/topological_navigation_tester_supplementary.py
@@ -28,17 +28,17 @@ class TestTopologicalNavigation(unittest.TestCase):
             self.assertTrue(False)
         return res
 
-    def test_static_facing_wall_1cm_distance_0_degrees_goal_behind(self):
+    def test_static_facing_wall_10cm_distance_0_degrees_goal_behind(self):
         res = self._run(self._map_name+str(1))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
-    def test_static_facing_wall_1cm_distance_minus_45_degrees_goal_behind(self):
+    def test_static_facing_wall_10cm_distance_minus_45_degrees_goal_behind(self):
         res = self._run(self._map_name+str(2))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
 
-    def test_static_facing_wall_1cm_distance_plus_45_degrees_goal_behind(self):
+    def test_static_facing_wall_10cm_distance_plus_45_degrees_goal_behind(self):
         res = self._run(self._map_name+str(3))
         rospy.loginfo(res)
         self.assertTrue(res.nav_success)
@@ -86,7 +86,7 @@ class TestTopologicalNavigation(unittest.TestCase):
     def test_static_wheelchair_on_end_point(self):
         res = self._run(self._map_name+str(12))
         rospy.loginfo(res)
-        self.assertTrue(res.graceful_fail)  # Cannot reach final node
+        self.assertTrue(res.graceful_fail and not res.nav_timeout)  # Cannot reach final node and navigation should fail without timeout
 
     def test_static_human_on_intermediate_point(self):
         res = self._run(self._map_name+str(13))
@@ -96,7 +96,7 @@ class TestTopologicalNavigation(unittest.TestCase):
     def test_static_human_on_end_point(self):
         res = self._run(self._map_name+str(14))
         rospy.loginfo(res)
-        self.assertTrue(res.graceful_fail)  # Cannot reach final node
+        self.assertTrue(res.graceful_fail and not res.nav_timeout)  # Cannot reach final node and navigation should fail without timeout
 
     def test_static_chairs_on_one_side_of_corridor(self):
         res = self._run(self._map_name+str(15))
@@ -111,12 +111,12 @@ class TestTopologicalNavigation(unittest.TestCase):
     def test_static_corridor_blocked_by_wheelchairs(self):
         res = self._run(self._map_name+str(17))
         rospy.loginfo(res)
-        self.assertTrue(res.graceful_fail) # Cannot reach final node
+        self.assertTrue(res.graceful_fail and not res.nav_timeout) # Cannot reach final node and navigation should fail without timeout
 
     def test_static_corridor_blocked_by_humans(self):
         res = self._run(self._map_name+str(18))
         rospy.loginfo(res)
-        self.assertTrue(res.graceful_fail) # Cannot reach final node
+        self.assertTrue(res.graceful_fail and not res.nav_timeout) # Cannot reach final node and navigation should fail without timeout
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently, the impossible tests, i.e. blocking the way or the final node, require that the graceful death attempt is successful, meaning that the robot is able to navigate back to `start` after the navigation to `end` failed. With this PR, a new field for the service is added, giving feedback if the navigation timed out or if it failed on its own accord. Impossible tests are therefore only passed, if the navigation failed without timing out and if graceful death was successful.
