### PR TITLE
Making localise by topic wait for the topic to be published

### DIFF
--- a/topological_navigation/scripts/localisation.py
+++ b/topological_navigation/scripts/localisation.py
@@ -87,10 +87,10 @@ class TopologicalNavLoc(object):
         subscribers = []
         for j in self.nodes_by_topic:
             # Nested lambda function to preserve the scope of j.
-            subscribe = LocaliseByTopicSubscriber(j['topic'], (lambda y: lambda x: self.Callback(x,y))(j))
-            # Calling instance of class to start subsribing thread. Append to
-            # list to keep the instance alive and the subscriber active.
-            subscribers.append(subscribe())
+            # Append to list to keep the instance alive and the subscriber active.
+            subscribers.append(LocaliseByTopicSubscriber(j['topic'], (lambda y: lambda x: self.Callback(x,y))(j)))
+            # Calling instance of class to start subsribing thread.
+            subscribers[-1]()
 
         rospy.loginfo("Subscribing to robot pose")
         rospy.Subscriber("/robot_pose", Pose, self.PoseCallback)


### PR DESCRIPTION
This solves a race condition for the topological navigation. Currently, localise by topic, e.g. for the charging station, assumes that the topic is there when topo nav is started and fails other wise. Since I am using this functionality in the walking group as well, I cannot assume that the walking group is running before the topo nav is started.

This is solved using a helper class. An instance of this class is created for every subscriber, getting the topic name and the callback as an argument. When this instance is called, a thread is started that waits for the topic to be published and then subscribes as soon as it gets the topic type. As long as the instance of this class is kept alive, the subscriber is kept alive as well.

@Jailander please have a look if that is alright with you, tested it in simulation.

A different way of solving this, would be to give the topic type as a string, e.g. `scitos_msgs/BatteryState` in the localise by topic json dictionary so you don't have to wait to get the topic type from the running topic.

Suggested solution:

``` python
j = {"topic": "/battery_state", "topic_type": "scitos_msgs/BatteryState", ...}
rospy.Subscriber(j["topic"], roslib.message.get_message_class(j["topic_type"]), ...)
```

Both version have the same result but the one proposed in this PR hides a bit of complexity from the user where the other spares you the whole threading mess. Up to you @Jailander 

P.S.: Also involuntary removing a few unnecessary spaces ;)

**Edit:**

_The proposed solution also has the benefit of not having to alter all existing topological maps which you would have when including the type in the json string._
