### PR TITLE
Monkey patching localisation by topic to wait longer between polls

### DIFF
--- a/topological_navigation/scripts/localisation.py
+++ b/topological_navigation/scripts/localisation.py
@@ -33,6 +33,31 @@ class LocaliseByTopicSubscriber(object):
         self.sub = None
         self.t = None
 
+    def get_topic_type(self, topic, blocking=False):
+        """
+        Get the topic type.
+        !!! Overriden from rostopic !!!
+
+        :param topic: topic name, ``str``
+        :param blocking: (default False) block until topic becomes available, ``bool``
+
+        :returns: topic type, real topic name and fn to evaluate the message instance
+          if the topic points to a field within a topic, e.g. /rosout/msg. fn is None otherwise. ``(str, str, fn)``
+        :raises: :exc:`ROSTopicException` If master cannot be contacted
+        """
+        topic_type, real_topic, msg_eval = rostopic._get_topic_type(topic)
+        if topic_type:
+            return topic_type, real_topic, msg_eval
+        elif blocking:
+            sys.stderr.write("WARNING: topic [%s] does not appear to be published yet\n"%topic)
+            while not rospy.is_shutdown():
+                topic_type, real_topic, msg_eval = rostopic._get_topic_type(topic)
+                if topic_type:
+                    return topic_type, real_topic, msg_eval
+                else:
+                    rostopic._sleep(10.) # Change! Waiting for 10 seconds instead of 0.1 to reduce load
+        return None, None, None
+
     def __call__(self):
         """
         When called start a new thread that waits for the topic type and then
@@ -46,6 +71,7 @@ class LocaliseByTopicSubscriber(object):
         Get the topic type and subscribe to topic. Subscriber is kept alive as
         long as the instance of the class is alive.
         """
+        rostopic.get_topic_type = self.get_topic_type # Monkey patch
         topic_type = rostopic.get_topic_class(self.topic, True)[0]
         rospy.loginfo("Subscribing to %s" % self.topic)
         self.sub = rospy.Subscriber(


### PR DESCRIPTION
The new waiting for the topic type was producing unnecessary high loads while waiting. Since there is one subscriber per node that uses localise by topic, this created quite a few threads that all polled the topic type every 0.1 seconds. Sadly, this method is hidden in `rostopic` and not part of a class so cannot be easily overridden.

This PR "monkey patches" this method meaning that it defines its own version of the function with a longer wait and then replaces the function in `rostopic` with this new function. As a consequence, every call to this function or function that uses it like `rostopic.get_topic_class` will use this new version of the function. This is very dirty but since this waiting time is not exposed, there is no other way to do this despite from reimplementing all the other functions. I could have monkey patched the `_sleep` function as well but this used in quite a few other places as well.

As a result, everything that uses `rostopic.get_topic_type` will now wait 10 seconds between polls of the type instead of 0.1 seconds. I don't think that this is a critical change but should reduce the number of polls significantly.
