### PR TITLE
Update strands_rviz_topmap.launch

### DIFF
--- a/topological_rviz_tools/launch/strands_rviz_topmap.launch
+++ b/topological_rviz_tools/launch/strands_rviz_topmap.launch
@@ -1,7 +1,7 @@
 <launch>
-  <arg name="topmap" default="tsc_1611"/>
-  <arg name="map" default="$(find tsc_bringup)/maps/tsc_1611/tsc_1611.yaml"/>
-  <arg name="db_path" default="/storage/mongodb_store"/>
+  <arg name="topmap"/>
+  <arg name="map"/>
+  <arg name="db_path"/>
   <arg name="rviz" default="true"/>
 
   <include file="$(find mongodb_store)/launch/mongodb_store.launch">


### PR DESCRIPTION
The line default="$(find tsc_bringup)/maps/tsc_1611/tsc_1611.yaml is giving error even when "map" argument is provided (if there is no tsc_bringup package). As this package is STRANDS specific, I think there shouldnt be default value for long-term or external use. Hence, I deleted the other default values too. 