### PR TITLE
Ensure that meta out is defined to prevent crashes

### DIFF
--- a/topological_navigation/src/topological_navigation/manager.py
+++ b/topological_navigation/src/topological_navigation/manager.py
@@ -162,6 +162,7 @@ class map_manager(object):
         #print len(available)
         if len(available) != 1:
              succeded = False
+             meta_out = None
              print 'there are no nodes or more than 1 with that name'
         else:
             succeded = True
@@ -195,6 +196,7 @@ class map_manager(object):
     def add_tag_cb(self, msg):
         #rospy.loginfo('Adding Tag '+msg.tag+' to '+str(msg.node))
         succeded = True
+        meta_out = None
         for j in msg.node:
 
             msg_store = MessageStoreProxy(collection='topological_maps')
@@ -240,6 +242,7 @@ class map_manager(object):
             available = msg_store.query(strands_navigation_msgs.msg.TopologicalNode._type, query, query_meta)
             #print len(available)
             succeded = False
+            meta_out = None
             for i in available:
                 msgid= i[1]['_id']
                 if 'tag' in i[1]:
@@ -256,6 +259,7 @@ class map_manager(object):
 
     def modify_tag_cb(self, msg):
         succeded = True
+        meta_out = None
         for node in msg.node:
             msg_store = MessageStoreProxy(collection='topological_maps')
             query = {"name" : node, "pointset": self.nodes.name}


### PR DESCRIPTION
Fixes the following crash, which happened to me while attempting to remove a tag.

```
[ERROR] [1501510390.765627]: Error processing request: local variable 'meta_out' referenced before assignment
['Traceback (most recent call last):\n', '  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/impl/tcpros_service.py", line 625, in _handle_request\n    response = convert_return_to_response(self.handler(request), self.response_class)\n', '  File "/home/michal/catkin_ws/src/strands_navigation/topological_navigation/src/topological_navigation/manager.py", line 255, in rm_tag_cb\n    return succeded, meta_out\n', "UnboundLocalError: local variable 'meta_out' referenced before assignment\n"]
[ERROR] [1501510390.766215475]: Service call failed: service [/topological_map_manager/rm_tag_from_node] responded with an error: error processing request: local variable 'meta_out' referenced before assignment
```