### PR TITLE
tmap to yaml  - adding meta info to nodes

### DIFF
--- a/topological_utils/scripts/map_to_json.py
+++ b/topological_utils/scripts/map_to_json.py
@@ -69,13 +69,13 @@ class MapExport(object):
                 nodeinf["meta"].pop("last_updated_by", None)
                 nodeinf["meta"].pop('inserted_at', None)
                 nodeinf["meta"].pop('last_updated_at', None)
-                nodeinf["meta"].pop('stored_type', None)            
-                nodeinf["meta"].pop('stored_class', None) 
+                nodeinf["meta"].pop('stored_type', None)
+                nodeinf["meta"].pop('stored_class', None)
                 nodeinf["meta"].pop('inserted_by', None)
                 nodeinf["meta"].pop('_id', None)
                 top_map.append(nodeinf)
-                #val = bson.json_util.dumps(nodeinf["meta"], indent=1)       
-            
+                #val = bson.json_util.dumps(nodeinf["meta"], indent=1)
+
             fh = open(filename, "w")
             #s_output = str(bson.json_util.dumps(nodeinf, indent=1))
             s_output = str(bson.json_util.dumps(top_map, indent=1, sort_keys=True) )
@@ -86,7 +86,7 @@ class MapExport(object):
 
 if __name__ == '__main__':
     if len(sys.argv) < 3 :
-        print "usage: map_export dataset_name output_file.tplg"
+        print "usage: map_to_json dataset_name output_file.json"
         sys.exit(2)
 
     dataset_name=str(sys.argv[1])

--- a/topological_utils/scripts/map_to_yaml.py
+++ b/topological_utils/scripts/map_to_yaml.py
@@ -65,27 +65,27 @@ class MapExport(object):
                 nodeinf["meta"].pop("last_updated_by", None)
                 nodeinf["meta"].pop('inserted_at', None)
                 nodeinf["meta"].pop('last_updated_at', None)
-                nodeinf["meta"].pop('stored_type', None)            
-                nodeinf["meta"].pop('stored_class', None) 
+                nodeinf["meta"].pop('stored_type', None)
+                nodeinf["meta"].pop('stored_class', None)
                 nodeinf["meta"].pop('inserted_by', None)
                 nodeinf["meta"].pop('_id', None)
                 top_map.append(nodeinf)
-                #val = bson.json_util.dumps(nodeinf["meta"], indent=1)       
-            
-            
-            
+                #val = bson.json_util.dumps(nodeinf["meta"], indent=1)
+
+
+
             top_map.sort(key=lambda x: x['node']['name'])
             yml = yaml.safe_dump(top_map, default_flow_style=False)
             #print yml
             #print s_output
-            
+
             fh = open(filename, "w")
             #s_output = str(bson.json_util.dumps(nodeinf, indent=1))
             s_output = str(yml)
             #print s_output
             fh.write(s_output)
-            fh.close            
-            
+            fh.close
+
 #            fh = open(filename, "w")
 #            #s_output = str(bson.json_util.dumps(nodeinf, indent=1))
 #            s_output = str(bson.json_util.dumps(top_map, indent=1, sort_keys=True) )
@@ -96,7 +96,7 @@ class MapExport(object):
 
 if __name__ == '__main__':
     if len(sys.argv) < 3 :
-        print "usage: map_export dataset_name output_file.tplg"
+        print "usage: map_to_yaml dataset_name output_file.yaml"
         sys.exit(2)
 
     dataset_name=str(sys.argv[1])

--- a/topological_utils/scripts/tmap_to_yaml.py
+++ b/topological_utils/scripts/tmap_to_yaml.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #==============================================================================
-# This Script takes a topological map file (.tmap) and creates a Yaml file with 
+# This Script takes a topological map file (.tmap) and creates a Yaml file with
 # the topological map definition
 #
 # Usage:
@@ -33,7 +33,7 @@ class topological_node(object):
 
     def _insert_waypoint(self, swaypoint):
         self.waypoint=swaypoint.split(',')
-        
+
     def _insert_edges(self, edges):
         self.edges=edges
 
@@ -48,11 +48,11 @@ def get_edge_id(source, target, eids):
         eid = '%s_%s_%3d' %(source, target, test)
         test += 1
     return eid
-        
+
 
 def loadMap(inputfile, dataset_name, map_name) :
 
-    print "openning %s" %inputfile 
+    print "openning %s" %inputfile
     fin = open(inputfile, 'r')
     print "Done"
 
@@ -68,7 +68,7 @@ def loadMap(inputfile, dataset_name, map_name) :
             name = name.strip('\n')
             anode=topological_node(name, dataset_name, map_name)
 
-            #Saving WayPoint            
+            #Saving WayPoint
             line = fin.readline()
             if line.startswith('\t') :
                 if line.startswith('\twaypoint:') :
@@ -77,7 +77,7 @@ def loadMap(inputfile, dataset_name, map_name) :
                     ways = line.strip('\t')
                     ways = ways.strip('\n')
                     anode._insert_waypoint(ways)
-                    
+
             #Saving edges
             line = fin.readline()
             if line.startswith('\t') :
@@ -95,7 +95,7 @@ def loadMap(inputfile, dataset_name, map_name) :
                     anode._insert_edges(edges)
 
             #Saving vertices
-            #line = fin.readline()                    
+            #line = fin.readline()
             if line.startswith('\t') :
                 if line.startswith('\tvertices:') :
                     vertices=[]
@@ -111,7 +111,7 @@ def loadMap(inputfile, dataset_name, map_name) :
     fin.close()
     lnodes.pop(0)
 
-    return lnodes         
+    return lnodes
 
 
 if __name__ == '__main__':
@@ -131,7 +131,7 @@ if __name__ == '__main__':
     meta = {}
     meta["map"] = map_name
     meta["pointset"] = dataset_name
-        
+
     for i in lnodes:
         n = TopologicalNode()
         n.name = i.name
@@ -163,25 +163,25 @@ if __name__ == '__main__':
             e.map_2d = map_name
 #            e.use_default_recovery = True
 #            e.use_default_nav_recovery = True
-#            e.use_default_helpers = True            
+#            e.use_default_helpers = True
             n.edges.append(e)
         nnodes.append(n)
 
-    
+
     onodes = []
     for i in nnodes:
-        r = []
+        r = {}
         q = dc_util.msg_to_document(i)
         m = {}
         m["map"] = map_name
         m["pointset"] = dataset_name
         m["node"] = n.name
-        r.append(q)
-        r.append(m)
+        r["meta"] = m
+        r["node"] = q
         onodes.append(r)
 
 
-    onodes.sort(key=lambda x: x[0]['name'])
+    onodes.sort(key=lambda x: x["node"]['name'])
     yml = yaml.safe_dump(onodes, default_flow_style=False)
     #print yml
     #print s_output


### PR DESCRIPTION
When a yaml file is created from a tmap, "meta" and "node" tags are missing. This yaml file is not as per the format used for topological map. Also, this yaml file cannot be imported to mongodb.

One option is to remove the tmap_to_yaml option as "meta" tag is missing in tmap and there will be some information loss when a yaml is generated from it. Another is to populate as much meta info available in tmap to yaml. In this the latter approach is taken, by adding some meta tag to the objects in the yaml file.