### PR TITLE
Standalone easier to run on strands robots

### DIFF
--- a/topological_rviz_tools/launch/strands_rviz_topmap.launch
+++ b/topological_rviz_tools/launch/strands_rviz_topmap.launch
@@ -1,14 +1,23 @@
 <launch>
   <arg name="topmap"/>
   <arg name="map"/>
-  <arg name="db_path"/>
   <arg name="rviz" default="true"/>
+  <!-- If standalone, launches everything necessary to edit the topological map,
+       including dummy navigation -->
   <arg name="standalone" default="true"/>
+  <!-- By default, the database will also be launched. On the strands robots the
+       database might be on one of the side PCs, while you need rviz running on
+       the main pc. Setting this option to false you can run the database on the
+       correct machine before starting -->
+  <arg name="launch_db" default="true"/>
 
   <group if="$(arg standalone)">
-    <include file="$(find mongodb_store)/launch/mongodb_store.launch">
-      <arg name="db_path" value="$(arg db_path)"/>
-    </include>
+    <group if="$(arg launch_db)">
+      <arg name="db_path"/>
+      <include file="$(find mongodb_store)/launch/mongodb_store.launch">
+	<arg name="db_path" value="$(arg db_path)"/>
+      </include>
+    </group>
 
     <node pkg="tf" type="static_transform_publisher" name="map_odom_bc" args="1 0 0 0 0 0 1 odom map 100" />
 


### PR DESCRIPTION
Would have to run with rviz=false on the side PC which has the database and then run rviz on the main PC if the database is on on of the side PCs. With this change can run the database on the side PC and then run this with launch_db:=false to not have to run rviz separately.