### PR TITLE
Move base parameters being reconfigured at edges

### DIFF
--- a/strands_navigation_msgs/CMakeLists.txt
+++ b/strands_navigation_msgs/CMakeLists.txt
@@ -71,6 +71,7 @@ add_service_files(
   UpdateNodeName.srv
   UpdateEdge.srv
   UpdateNodeTolerance.srv
+  ReconfAtEdges.srv
 )
 
 

--- a/strands_navigation_msgs/srv/ReconfAtEdges.srv
+++ b/strands_navigation_msgs/srv/ReconfAtEdges.srv
@@ -1,0 +1,3 @@
+string edge_id
+---
+bool success

--- a/topological_navigation/launch/reconf_at_edges_server.launch
+++ b/topological_navigation/launch/reconf_at_edges_server.launch
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<launch>
+
+  <arg name="omni" default="false" />
+
+  <!-- Reconfigure -->
+  <node pkg="topological_navigation" type="reconf_at_edges_server.py" name="reconf_at_edges_server" output="screen" 
+        args="$(arg omni)" respawn="true">
+    <remap from="/move_base/DWAPlannerROS/set_parameters" to="move_base/DWAPlannerROS/set_parameters" />
+  </node>
+
+</launch>

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -148,7 +148,7 @@ class TopologicalNavServer(object):
         rospy.spin()
 
     def init_reconfigure(self):
-        self.move_base_planner = rospy.get_param('~move_base_planner', 'move_base/DWAPlannerROS')
+        #self.move_base_planner = rospy.get_param('~move_base_planner', 'move_base/DWAPlannerROS')
         #Creating Reconfigure Client
         rospy.loginfo("Creating Reconfigure Client")
         self.rcnfclient = dynamic_reconfigure.client.Client(self.move_base_planner)
@@ -178,6 +178,7 @@ class TopologicalNavServer(object):
         
         
     def reconfigure_movebase_params(self, params):
+        self.move_base_planner = rospy.get_param('~move_base_planner', 'move_base/DWAPlannerROS')
         translated_params = {}
         key = self.move_base_planner[self.move_base_planner.rfind('/') + 1:]
         translation = DYNPARAM_MAPPING[key]

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -148,7 +148,7 @@ class TopologicalNavServer(object):
         rospy.spin()
 
     def init_reconfigure(self):
-        #self.move_base_planner = rospy.get_param('~move_base_planner', 'move_base/DWAPlannerROS')
+        self.move_base_planner = rospy.get_param('~move_base_planner', 'move_base/DWAPlannerROS')
         #Creating Reconfigure Client
         rospy.loginfo("Creating Reconfigure Client")
         self.rcnfclient = dynamic_reconfigure.client.Client(self.move_base_planner)

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -563,7 +563,7 @@ class TopologicalNavServer(object):
             rindex=rindex+1
 
 
-        self.reset_reconf() 
+        #self.reset_reconf() 
 
 
         self.navigation_activated=False

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -563,7 +563,7 @@ class TopologicalNavServer(object):
             rindex=rindex+1
 
 
-        #self.reset_reconf() 
+        self.reset_reconf() 
 
 
         self.navigation_activated=False

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -178,7 +178,8 @@ class TopologicalNavServer(object):
         
         
     def reconfigure_movebase_params(self, params):
-        self.move_base_planner = rospy.get_param('~move_base_planner', 'move_base/DWAPlannerROS')
+        #self.move_base_planner = rospy.get_param('~move_base_planner', 'move_base/DWAPlannerROS')
+        self.init_dynparams = self.rcnfclient.get_configuration()
         translated_params = {}
         key = self.move_base_planner[self.move_base_planner.rfind('/') + 1:]
         translation = DYNPARAM_MAPPING[key]

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -400,7 +400,7 @@ class TopologicalNavServer(object):
         print "current group: ", self.current_edge_group
         print "edge group: ", edge_group
         
-        if edge_group is not self.current_edge_group and edge_group != 'none':
+        if edge_group is not self.current_edge_group: # and edge_group != 'none':
             print "RECONFIGURING EDGE: ", edge_id
             print "TO ", edge_group 
             self.current_edge_group = edge_group

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -14,7 +14,7 @@ from strands_navigation_msgs.msg import MonitoredNavigationGoal
 from strands_navigation_msgs.msg import NavStatistics
 from strands_navigation_msgs.msg import CurrentEdge
 
-from rasberry_optimise.srv import ReconfAtEdges
+from strands_navigation_msgs.srv import ReconfAtEdges
 
 from actionlib_msgs.msg import *
 from move_base_msgs.msg import *

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -401,12 +401,13 @@ class TopologicalNavServer(object):
         if edge_group is not self.current_edge_group: # and edge_group != 'none':
             print "RECONFIGURING EDGE: ", edge_id
             print "TO ", edge_group
-            self.current_edge_group = edge_group
             try:
                 rospy.wait_for_service('reconf_at_edges', timeout=3)
                 reconf_at_edges = rospy.ServiceProxy('reconf_at_edges', ReconfAtEdges)
                 resp1 = reconf_at_edges(edge_id)
                 print resp1.success
+                if resp1.success: # set current_edge_group only if successful
+                    self.current_edge_group = edge_group
             except rospy.ServiceException, e:
                 rospy.logerr("Service call failed: %s"%e)
         print "-------"

--- a/topological_navigation/scripts/reconf_at_edges_server.py
+++ b/topological_navigation/scripts/reconf_at_edges_server.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+import rospy, dynamic_reconfigure.client
+from strands_navigation_msgs.srv import ReconfAtEdges, ReconfAtEdgesResponse
+
+
+class reconf_at_edges_server(object):
+
+
+    def __init__(self):
+        self.edge_groups = rospy.get_param("edge_nav_reconfig_groups", {})
+        rospy.Service('reconf_at_edges', ReconfAtEdges, self.handle_reconf_at_edges)
+
+
+    def handle_reconf_at_edges(self, req):
+
+        self.success = False
+        for group in self.edge_groups:
+
+            if req.edge_id in self.edge_groups[group]["edges"]:
+                rospy.loginfo("\nSetting parameters for edge group {} ...".format(group))
+
+                self.set_parameters(group)
+                break
+
+        return ReconfAtEdgesResponse(self.success)
+
+
+    def set_parameters(self, group):
+
+        try:
+            for param in self.edge_groups[group]["parameters"]:
+                print "Setting {} = {}".format("/".join((param["ns"], param["name"])), param["value"])
+
+                rcnfclient = dynamic_reconfigure.client.Client(param["ns"], timeout=5.0)
+                rcnfclient.update_configuration({param["name"]: param["value"]})
+
+            self.success = True
+
+        except rospy.ROSException as e:
+            rospy.logerr(e)
+
+
+
+
+if __name__ == "__main__":
+
+    rospy.init_node('reconf_at_edges_server', anonymous=True)
+    reconf_at_edges_server()
+    rospy.spin()
+#####################################################################################

--- a/topological_navigation/scripts/reconf_at_edges_server.py
+++ b/topological_navigation/scripts/reconf_at_edges_server.py
@@ -7,13 +7,14 @@ class reconf_at_edges_server(object):
 
 
     def __init__(self):
-        self.edge_groups = rospy.get_param("edge_nav_reconfig_groups", {})
+        self.edge_groups = rospy.get_param("/edge_nav_reconfig_groups", {})
         rospy.Service('reconf_at_edges', ReconfAtEdges, self.handle_reconf_at_edges)
 
 
     def handle_reconf_at_edges(self, req):
 
         self.success = False
+
         for group in self.edge_groups:
 
             if req.edge_id in self.edge_groups[group]["edges"]:


### PR DESCRIPTION
When this mode is enabled via the `/topological_navigation/reconfigure_edges` parameters, topological navigation will change action parameters according to the `/edge_nav_reconfig_groups` parameters values and edges, an example of this configuration is as follows:

```
edge_nav_reconfig_groups:
  irn:
    edges:
      - WayPoint1_WayPoint2
    parameters:
      - &id001
        name: forward_point_distance
        ns: move_base/DWAPlannerROS
        type: double
        value: 0.48297542551971
  orn:
    edges:
      - WayPoint66_WayPoint57
    parameters:
      - *id001
  utn:
    edges:
      - WayPoint46_WayPoint47
    parameters:
      - name: forward_point_distance
        ns: move_base/DWAPlannerROS
        type: double
        value: 0.1402690117118645
```