### PR TITLE
enable edge_reconfig for execute_policy_mode server

### DIFF
--- a/strands_navigation/package.xml
+++ b/strands_navigation/package.xml
@@ -38,7 +38,7 @@
   <!-- Use run_depend for packages you need at runtime: -->
 
   <run_depend>joy_map_saver</run_depend>
-  <run_depend>message_store_map_switcher</run_depend>
+
   <run_depend>monitored_navigation</run_depend>
   <run_depend>nav_goals_generator</run_depend>
   <run_depend>strands_navigation_msgs</run_depend>

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -170,7 +170,7 @@ class TopologicalNavServer(object):
                 cytol = cnode.yaw_goal_tolerance
         else:
             cytol = 6.283
-        params = { 'yaw_goal_tolerance' : cytol, '':cxygtol }   # No orientation restrictions, 'max_vel_x':ctopvel,
+        params = { 'yaw_goal_tolerance' : cytol, 'xy_goal_tolerance':cxygtol }   # No orientation restrictions, 'max_vel_x':ctopvel,
         print "reconfiguring %s with %s" % (self.move_base_name, params)
         print intermediate
         self.reconfigure_movebase_params(params)

--- a/topological_navigation/src/topological_navigation/route_search.py
+++ b/topological_navigation/src/topological_navigation/route_search.py
@@ -30,6 +30,9 @@ class TopologicalRouteSearch(object):
      This function searches the route to reach the goal
     """
     def search_route(self, origin, target):
+        if origin == "none" or target == "none" or origin == target:
+            return None
+
         goal = get_node(self.top_map, target)
         orig = get_node(self.top_map, origin)
         to_expand=[]

--- a/topological_navigation/src/topological_navigation/route_search.py
+++ b/topological_navigation/src/topological_navigation/route_search.py
@@ -16,17 +16,17 @@ class NodeToExpand(object):
 
     def __repr__(self):
         return "-------\n\t Node: \n\t name:%s \n\t Father:%s \n\t current_distance:%f \n\t distance to target: %f \n\t cost %f \n" %(self.name, self.father, self.current_distance, self.dist_to_target, self.cost)
-        
+
 
 class TopologicalRouteSearch(object):
-       
+
     def __init__(self, top_map) :
-        rospy.loginfo("Waiting for Topological map ...")
+#        rospy.loginfo("Waiting for Topological map ...")
         self.top_map = top_map
 
     """
      search_route
-     
+
      This function searches the route to reach the goal
     """
     def search_route(self, origin, target):
@@ -35,17 +35,17 @@ class TopologicalRouteSearch(object):
         to_expand=[]
         children=[]
         expanded=[]
-        
+
         #print 'searching route from %s to %s' %(orig.name, goal.name)
-        
+
         #self.get_distance_to_node(goal, orig)
         nte = NodeToExpand(orig.name, 'none', 0.0, get_distance_to_node(goal, orig))  #Node to Expand
         expanded.append(nte)
         #to_expand.append(nte)
-        
+
 #        exp_index=0
-        cen = orig      #currently expanded node 
-        
+        cen = orig      #currently expanded node
+
         children = get_conected_nodes(cen) #nodes current node is connected to
         #print children
         not_goal=True
@@ -68,7 +68,7 @@ class TopologicalRouteSearch(object):
                     for j in to_expand:
                         if i == j.name:
                             been_expanded = True
-                            
+
                     if not been_expanded:
                         nnn = get_node(self.top_map, i)
                         tdist = get_distance_to_node(goal, nnn)
@@ -86,7 +86,7 @@ class TopologicalRouteSearch(object):
                 else:
                     not_goal=False
                     route_found=False
-        
+
         route = NavRoute()
 #        print "===== RESULT ====="
         if route_found:
@@ -101,7 +101,7 @@ class TopologicalRouteSearch(object):
                         steps.append(i)
                         next_node = i.father
                         break
-            
+
             steps.reverse()
             val = len(steps)
             for i in range(1, val):
@@ -109,7 +109,7 @@ class TopologicalRouteSearch(object):
                 route.source.append(steps[i].father)
                 route.edge_id.append(edg[0].edge_id)
                 #route.append(r)
-        
+
             return route
         else:
             return None


### PR DESCRIPTION
1. edge reconfig ported from topological_navigation/navigation.py (#374 )

When this mode is enabled via the `/topological_navigation/execute_policy_mode/reconfigure_edges` parameter, `execute_navigation_mode` action server will change edge action parameters (e.g. `move_base/DWAPlannerROS`) according to the `/edge_nav_reconfig_groups` parameter's values and edges being navigated, an example of this configuration is as follows:

```
edge_nav_reconfig_groups:
  irn:
    edges:
      - WayPoint1_WayPoint2
      - WayPoint2_WayPoint3
      - WayPoint3_WayPoint4
    parameters:
      - &id001
        name: forward_point_distance
        ns: move_base/DWAPlannerROS
        type: double
        value: 0.48297542551971
  orn:
    edges:
      - WayPoint66_WayPoint57
      - WayPoint57_WayPoint66
    parameters:
      - *id001
  utn:
    edges:
      - WayPoint46_WayPoint47
    parameters:
      - name: forward_point_distance
        ns: move_base/DWAPlannerROS
        type: double
        value: 0.1402690117118645
```

2. minor fixes in
  - topological_navigation/navigation.py
  - topological_navigation/route_search.py